### PR TITLE
Add extension manifest schema

### DIFF
--- a/resources/asdf-format.org/core/schemas/extension_manifest-1.0.yaml
+++ b/resources/asdf-format.org/core/schemas/extension_manifest-1.0.yaml
@@ -38,7 +38,7 @@ properties:
       Long description of the extension.
     type: string
 
-  asdf_standard_version:
+  asdf_standard_requirement:
     description: >
       ASDF Standard version requirement.
     anyOf:

--- a/resources/asdf-format.org/core/schemas/extension_manifest-1.0.yaml
+++ b/resources/asdf-format.org/core/schemas/extension_manifest-1.0.yaml
@@ -1,0 +1,102 @@
+%YAML 1.1
+---
+$schema: http://stsci.edu/schemas/yaml-schema/draft-01
+id: asdf://asdf-format.org/core/schemas/extension_manifest-1.0
+title: ASDF extension manifest
+description: >
+  Manifest of additional tags and other features associated
+  with an extension to the ASDF Standard.  This schema is
+  provisional and not yet included in any ASDF Standard version.
+
+definitions:
+  version:
+    description: >
+      A string property whose value matches a 1-3 part
+      version number (pre-release version not permitted).
+    type: string
+    pattern: '^(0|[1-9]\d*)(\.(0|[1-9]\d*)){0,2}$'
+
+type: object
+properties:
+  id:
+    description: >
+      URI of the extension manifest resource.
+    type: string
+
+  extension_uri:
+    description: >
+      The extension's identifying URI.
+    type: string
+
+  title:
+    description: >
+      Short description of the extension.
+    type: string
+
+  description:
+    description: >
+      Long description of the extension.
+    type: string
+
+  asdf_standard_version:
+    description: >
+      ASDF Standard version requirement.
+    anyOf:
+      - description: >
+          Require exact version.
+        $ref: '#/definitions/version'
+      - type: object
+        properties:
+          gt:
+            description: >
+              Require versions greater than.
+            $ref: '#/definitions/version'
+          gte:
+            description: >
+              Require versions greater than or equal.
+            $ref: '#/definitions/version'
+          lt:
+            description: >
+              Require versions less than.
+            $ref: '#/definitions/version'
+          lte:
+            description: >
+              Require versions less than or equal.
+            $ref: '#/definitions/version'
+        additionalProperties: false
+
+  tags:
+    description: >
+      List of additional tags supported by this extension.
+    type: array
+    items:
+      anyOf:
+        - description: >
+            The tag's identifying URI.
+          type: string
+        - description: >
+            Tag definition object.
+          type: object
+          properties:
+            tag_uri:
+              description: >
+                The tag's identifying URI.
+              type: string
+            schema_uri:
+              description: >
+                URI of schema used to validate objects with this tag.
+              type: string
+            title:
+              description: >
+                Short description of the tag.
+              type: string
+            description:
+              description: >
+                Long description of the tag.
+              type: string
+          required: [tag_uri]
+          additionalProperties: false
+
+required: [id, extension_uri]
+additionalProperties: false
+...

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,17 @@
 [tool:pytest]
-asdf_schema_root = schemas
-asdf_schema_skip_names = asdf-schema-1.0.0 draft-01
-asdf_schema_skip_examples = domain-1.0.0 frame-1.0.0 frame-1.1.0
+asdf_schema_root = schemas resources/asdf-format.org/core/schemas
+asdf_schema_skip_names =
+    asdf-schema-1.0.0
+    draft-01
+    celestial_frame-1.0.0
+    celestial_frame-1.1.0
+    frame-1.1.0
+    spectral_frame-1.1.0
+    step-1.1.0
+    step-1.2.0
+    wcs-1.1.0
+    wcs-1.2.0
+asdf_schema_skip_examples = domain-1.0.0 frame-1.0.0
 asdf_schema_tests_enabled = true
 asdf_schema_ignore_unrecognized_tag = true
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
 pytest
 pyyaml
-# This is set to master to make the pytest plugin's asdf_schema_ignore_unrecognized_tag
-# option available.  We can switch back to PyPI once asdf 2.6.0 is released.
+# This is set to master to make changes to support the asdf:// URI scheme
+# available.  We can switch back to PyPI once asdf 2.8.0 is released.
 git+https://github.com/spacetelescope/asdf.git
 astropy
 gwcs


### PR DESCRIPTION
This is the schema that validates an extension manifest document, which will list tags associated with a specific version of an extension to ASDF.  Note several changes to the URI structure (which are all up for discussion):

Old URI style: `http://stsci.edu/schemas/asdf/core/extension_manifest-1.0.0`
New URI style: `asdf://asdf-format.org/core/schemas/extension_manifest-1.0`

- Change scheme from `http://` to `asdf://`.  Users report that `http://` is confusing because it seems to imply that the resource is available from that web address, or that the library is downloading something.
- Change authority from `stsci.edu` to `asdf-format.org`.
- Change path from `schemas/asdf/core` to `core/schemas`.  With the `asdf` scheme, there's no need to leave room for non-asdf schemas.  I swapped `core` and `schemas` because we're adding several new entity types (extensions, extension manifests, tags, binary transforms, etc) and I think it'll be more convenient to keep all core entities together in one namespace instead of distributed among several.  Tentatively I'm planning to give each official extension a dedicated path under `extensions`, e.g., `asdf://asdf-format.org/extensions/transform/schemas/...`.
- Drop the patch version.  To date we've never used a nonzero patch version on any of the schemas or tags.  I can't think of a scenario where it would be useful to do so.