### PR TITLE
Update documentation for 1.6.0 changes

### DIFF
--- a/docs/source/file_layout.rst
+++ b/docs/source/file_layout.rst
@@ -83,8 +83,9 @@ Each line must begin with a ``#`` character.
 Tree
 ----
 
-The tree stores structured information using `YAML Ain’t Markup
-Language (YAML™) 1.1 <http://yaml.org/spec/1.1/>`__ syntax.  While it
+The tree stores structured information using a subset of `YAML Ain’t Markup
+Language (YAML™) 1.1 <http://yaml.org/spec/1.1/>`__ syntax (see :ref:`yaml_subset` for
+details on YAML features that are excluded from ASDF).  While it
 is the main part of most ASDF files, it is entirely optional, and a
 ASDF file may skip it completely.  This is useful for creating files
 in :ref:`exploded`.  Interpreting the contents of this section is

--- a/docs/source/schemas.rst
+++ b/docs/source/schemas.rst
@@ -475,6 +475,30 @@ The ``allOf`` combiner means that any instance that is validated against
 ``software_extended-1.0.0`` will have to conform to both the base software schema
 and the properties specific to the extended schema.
 
+Default annotation
+------------------
+
+The JSON Schema spec includes a schema annotation attribute called ``default`` that
+can be used to describe the default value of a data attribute when that attribute
+is missing.  Previous versions of the ASDF Standard did not offer guidance on how
+to use ``default``.  The Python reference implementation read the default as a literal
+value and inserted that value into the tree when the corresponding attribute
+was otherwise missing.  Until version 2.8, it also removed attributes on write whose
+values matched their schema defaults.  The resulting files would appear to the
+casual viewer to be missing data, and may in fact be invalid against their schemas
+if the any of the removed attributes were required.
+
+Implementations **must not** remove attributes with default values from the tree.
+Beginning with ASDF Standard 1.6.0, implementations also must not fill default values
+directly from the schema.  Going forward the value of the ``default`` schema attribute
+may be a description that is not appropriate to use as a literal default value.
+For example::
+
+    default: An array of zeros matching the dimensions of the data array.
+
+For ASDF Standard < 1.6.0, filling default values from the schema is required.  This is
+necessary to support files written by older versions of the Python implementation.
+
 .. rubric:: Footnotes
 
 .. [#] Implementations may expose the control of validation on reading to the

--- a/docs/source/schemas.rst
+++ b/docs/source/schemas.rst
@@ -480,19 +480,25 @@ Default annotation
 
 The JSON Schema spec includes a schema annotation attribute called ``default`` that
 can be used to describe the default value of a data attribute when that attribute
-is missing.  Previous versions of the ASDF Standard did not offer guidance on how
-to use ``default``.  The Python reference implementation read the default as a literal
-value and inserted that value into the tree when the corresponding attribute
-was otherwise missing.  Until version 2.8, it also removed attributes on write whose
-values matched their schema defaults.  The resulting files would appear to the
-casual viewer to be missing data, and may in fact be invalid against their schemas
-if the any of the removed attributes were required.
+is missing.  Recent versions of the spec `point out <http://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.7.7.1.1>`__
+that there is no single correct way to choose an annotation value when multiple
+are available due to references and combiners.  This presents a problem when
+trying to fill in missing data in a file based on the schema ``default``: if
+multiple conflicting values are available, the software does not know how to choose.
+
+Previous versions of the ASDF Standard did not offer guidance on how
+to use ``default``.  The Python reference implementation read the first default
+that it encountered as a literal value and inserted that value into the tree when
+the corresponding attribute was otherwise missing.  Until version 2.8, it also
+removed attributes on write whose values matched their schema defaults.  The
+resulting files would appear to the casual viewer to be missing data, and may in
+fact be invalid against their schemas if the any of the removed attributes were required.
 
 Implementations **must not** remove attributes with default values from the tree.
 Beginning with ASDF Standard 1.6.0, implementations also must not fill default values
-directly from the schema.  Going forward the value of the ``default`` schema attribute
-may be a description that is not appropriate to use as a literal default value.
-For example::
+directly from the schema.  This will avoid ambiguity when multiple schema defaults
+are present, and also permit the ``default`` attribute to contain a description
+that is not appropriate to use as a literal default value.  For example::
 
     default: An array of zeros matching the dimensions of the data array.
 

--- a/docs/source/tree.rst
+++ b/docs/source/tree.rst
@@ -24,6 +24,41 @@ how schemas are defined and used by ASDF. :ref:`schema` describes in detail
 all of the schemas provided by the ASDF Standard.  reference to all of schemas
 in detail.
 
+.. _yaml_subset:
+
+YAML subset
+-----------
+
+For reasons of portability, some features of YAML 1.1 are not
+permitted in an ASDF tree.
+
+Restricted mapping keys
+^^^^^^^^^^^^^^^^^^^^^^^
+
+YAML itself places no restrictions on the object type used as a mapping key;
+floats, sequences, even mappings themselves can serve as a key.  For example,
+the following is a perfectly valid YAML document::
+
+      %YAML 1.1
+      ---
+      {foo: bar}:
+        3.14159: baz
+        [1, 2, 3]: qux
+      ...
+
+However, such a file may not be easily parsed in all languages.  Python,
+for example, does not include a hashable mapping type, so the two major
+Python YAML libraries both fail to construct the object described by this
+document.  Floating-point keys are described as "not recommended" in the
+YAML 1.1 spec because YAML does not specify an accuracy for floats.
+
+For these reasons, mapping keys in ASDF trees are restricted to
+the following scalar types:
+
+- bool
+- int
+- str
+
 .. _tags:
 
 Tags
@@ -259,3 +294,22 @@ comments with objects (mappings) by using the reserved key name
 ASDF parsers must not interpret or react programmatically to these
 comment values: they are for human reference only.  No schema may
 use ``//`` as a meaningful key.
+
+
+Null values
+-----------
+
+YAML permits serialization of null values using the ``null`` literal::
+
+    some_key: null
+
+Previous versions of the ASDF Standard were vague as to how nulls should
+be handled, and the Python reference implementation did not distinguish
+between keys with null values and keys that were missing altogether (and
+in fact, removed any keys assigned ``None`` from the tree on read or
+write).  Beginning with ASDF Standard 1.6.0, ASDF implementatations
+are required to preserve keys even if assigned null values.  This
+requirement does not extend back into previous versions, and users
+of the Python implementation should be advised that the YAML portion
+of a < 1.6.0 ASDF file containing null values may be modified in unexpected
+ways when read or written.


### PR DESCRIPTION
Included are new sections on:

- Handling the `default` schema annotation
- Restricted YAML features
- Handling null values in the tree