### PR TITLE
Fix metaschemas so that custom validators on nested objects can be checked

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -250,7 +250,7 @@ asdf_schema_standard_prefix = 'stsci.edu/asdf'
 # plugin.
 asdf_schema_reference_mappings = [
     ('tag:stsci.edu:asdf',
-     'http://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/'),
+     'http://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf'),
     ('http://json-schema.org/draft-04/schema',
      'http://json-schema.org/draft-04/json-schema-validation'),
 ]

--- a/schemas/stsci.edu/asdf/asdf-schema-1.0.0.yaml
+++ b/schemas/stsci.edu/asdf/asdf-schema-1.0.0.yaml
@@ -43,4 +43,52 @@ allOf:
           If `true`, the datatype must match exactly.
         type: boolean
         default: false
+
+      # Redefine JSON schema validators in terms of this document so that
+      # we can check nested objects:
+      additionalItems:
+        anyOf:
+          - type: boolean
+          - $ref: "#"
+      items:
+        anyOf:
+          - $ref: "#"
+          - $ref: "#/definitions/schemaArray"
+      additionalProperties:
+        anyOf:
+          - type: boolean
+          - $ref: "#"
+      definitions:
+        type: object
+        additionalProperties:
+          $ref: "#"
+      properties:
+        type: object
+        additionalProperties:
+          $ref: "#"
+      patternProperties:
+        type: object
+        additionalProperties:
+          $ref: "#"
+      dependencies:
+        type: object
+        additionalProperties:
+          anyOf:
+            - $ref: "#"
+            - $ref: "http://json-schema.org/draft-04/schema#definitions/stringArray"
+      allOf:
+        $ref: "#/definitions/schemaArray"
+      anyOf:
+        $ref: "#/definitions/schemaArray"
+      oneOf:
+        $ref: "#/definitions/schemaArray"
+      not:
+        $ref: "#"
+
+definitions:
+  schemaArray:
+    type: array
+    minItems: 1
+    items:
+      $ref: "#"
 ...

--- a/schemas/stsci.edu/yaml-schema/draft-01.yaml
+++ b/schemas/stsci.edu/yaml-schema/draft-01.yaml
@@ -105,4 +105,52 @@ allOf:
             - anyOf:
               - type: string
               - type: object
+
+      # Redefine JSON schema validators in terms of this document so that
+      # we can check nested objects:
+      additionalItems:
+        anyOf:
+          - type: boolean
+          - $ref: "#"
+      items:
+        anyOf:
+          - $ref: "#"
+          - $ref: "#/definitions/schemaArray"
+      additionalProperties:
+        anyOf:
+          - type: boolean
+          - $ref: "#"
+      definitions:
+        type: object
+        additionalProperties:
+          $ref: "#"
+      properties:
+        type: object
+        additionalProperties:
+          $ref: "#"
+      patternProperties:
+        type: object
+        additionalProperties:
+          $ref: "#"
+      dependencies:
+        type: object
+        additionalProperties:
+          anyOf:
+            - $ref: "#"
+            - $ref: "http://json-schema.org/draft-04/schema#definitions/stringArray"
+      allOf:
+        $ref: "#/definitions/schemaArray"
+      anyOf:
+        $ref: "#/definitions/schemaArray"
+      oneOf:
+        $ref: "#/definitions/schemaArray"
+      not:
+        $ref: "#"
+
+definitions:
+  schemaArray:
+    type: array
+    minItems: 1
+    items:
+      $ref: "#"
 ...

--- a/tests/test_asdf_schema.py
+++ b/tests/test_asdf_schema.py
@@ -1,5 +1,7 @@
 import pytest
 
+from jsonschema import ValidationError
+
 from common import load_yaml, SCHEMAS_PATH, assert_yaml_header_and_footer
 
 
@@ -9,3 +11,51 @@ def test_asdf_schema(path):
 
     # Asserting no exceptions here
     load_yaml(path)
+
+
+@pytest.mark.parametrize("path", SCHEMAS_PATH.glob("asdf-schema-*.yaml"))
+def test_nested_object_validation(path, create_validator):
+    """
+    Test that the validations are applied to nested objects.
+    """
+    metaschema = load_yaml(path)
+    validator = create_validator(metaschema)
+
+    schema = {
+        "$schema": metaschema["id"],
+        "type": "object",
+        "properties": {
+            "foo": {
+                "datatype": "float32",
+            },
+        },
+    }
+    # No error here
+    validator.validate(schema)
+
+    schema = {
+        "$schema": metaschema["id"],
+        "type": "object",
+        "properties": {
+            "foo": {
+                "datatype": "banana",
+            },
+        },
+    }
+    with pytest.raises(ValidationError, match="'banana' is not valid"):
+        validator.validate(schema)
+
+    schema = {
+        "$schema": metaschema["id"],
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "ndim": "twelve",
+                },
+            },
+        },
+    }
+    with pytest.raises(ValidationError):
+        validator.validate(schema)

--- a/tests/test_yaml_schema.py
+++ b/tests/test_yaml_schema.py
@@ -1,5 +1,7 @@
 import pytest
 
+from jsonschema import ValidationError
+
 from common import load_yaml, YAML_SCHEMA_PATH, list_schema_paths, assert_yaml_header_and_footer
 
 
@@ -9,3 +11,51 @@ def test_yaml_schema(path):
 
     # Asserting no exceptions here
     load_yaml(path)
+
+
+@pytest.mark.parametrize("path", YAML_SCHEMA_PATH.glob("*.yaml"))
+def test_nested_object_validation(path, create_validator):
+    """
+    Test that the validations are applied to nested objects.
+    """
+    metaschema = load_yaml(path)
+    validator = create_validator(metaschema)
+
+    schema = {
+        "$schema": metaschema["id"],
+        "type": "object",
+        "properties": {
+            "foo": {
+                "flowStyle": "block",
+            },
+        },
+    }
+    # No error here
+    validator.validate(schema)
+
+    schema = {
+        "$schema": metaschema["id"],
+        "type": "object",
+        "properties": {
+            "foo": {
+                "flowStyle": "funky",
+            },
+        },
+    }
+    with pytest.raises(ValidationError, match="'funky' is not one of"):
+        validator.validate(schema)
+
+    schema = {
+        "$schema": metaschema["id"],
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "propertyOrder": "a,b,c,d",
+                },
+            },
+        },
+    }
+    with pytest.raises(ValidationError):
+        validator.validate(schema)


### PR DESCRIPTION
Until now the metaschemas have been unable to check custom validators present in nested objects in the schema.  This PR redefines relevant JSON schema validators in terms of the current metaschema document to fix that issue.

Resolves #283 