### PR TITLE
Add core manifest files for all ASDF Standard versions

### DIFF
--- a/resources/asdf-format.org/core/manifests/core-1.0.0.yaml
+++ b/resources/asdf-format.org/core/manifests/core-1.0.0.yaml
@@ -1,0 +1,173 @@
+id: asdf://asdf-format.org/core/manifests/core-1.0.0
+extension_uri: asdf://asdf-format.org/core/extensions/core-1.0.0
+title: Core extension 1.0.0
+description: Tags for ASDF core objects.
+asdf_standard_requirement: 1.0.0
+tags:
+- tag_uri: tag:stsci.edu:asdf/core/asdf-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/asdf-1.0.0
+  title: Top-level schema for every ASDF file.
+  description: This schema contains the top-level attributes for every ASDF file.
+- tag_uri: tag:stsci.edu:asdf/core/column-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/column-1.0.0
+  title: A column in a table.
+  description: |-
+    Each column contains a name and an array of data, and an optional description
+    and unit.
+- tag_uri: tag:stsci.edu:asdf/core/complex-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/complex-1.0.0
+  title: Complex number value.
+  description: |-
+    Represents a complex number matching the following EBNF grammar
+
+    ```
+      dot           = "."
+      plus-or-minus = "+" | "-"
+      digit         = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+      sign          = "" | plus-or-minus
+      suffix        = "J" | "j" | "I" | "i"
+      inf           = "inf" | "INF"
+      nan           = "nan" | "NAN"
+      number        = digits | dot digits | digits dot digits
+      sci-suffix    = "e" | "E"
+      scientific    = number sci-suffix sign digits
+      real          = sign number | sign scientific
+      imag          = number suffix | scientific suffix
+      complex       = real | sign imag | real plus-or-minus imag
+    ```
+
+    Though `J`, `j`, `I` and `i` must be supported on reading, it is
+    recommended to use `i` on writing.
+
+    For historical reasons, it is necessary to accept as valid complex numbers
+    that are surrounded by parenthesis.
+- tag_uri: tag:stsci.edu:asdf/core/constant-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/constant-1.0.0
+  title: Specify that a value is a constant.
+  description: Used as a utility to indicate that value is a literal constant.
+- tag_uri: tag:stsci.edu:asdf/core/history_entry-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/history_entry-1.0.0
+  title: An entry in the file history.
+  description: |-
+    A record of an operation that has been performed
+    upon a file.
+- tag_uri: tag:stsci.edu:asdf/core/ndarray-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+  title: An *n*-dimensional array.
+  description: |-
+    There are two ways to store the data in an ndarray.
+
+    - Inline in the tree: This is recommended only for small arrays.  In
+      this case, the entire ``ndarray`` tag may be a nested list, in
+      which case the type of the array is inferred from the content.
+      (See the rules for type inference in the ``inline-data``
+      definition below.)  The inline data may also be given in the
+      ``data`` property, in which case it is possible to explicitly
+      specify the ``datatype`` and other properties.
+
+    - External to the tree: The data comes from a [block](ref:block)
+      within the same ASDF file or an external ASDF file referenced by a
+      URI.
+- tag_uri: tag:stsci.edu:asdf/core/software-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/software-1.0.0
+  title: Describes a software package.
+  description: General-purpose description of a software package.
+- tag_uri: tag:stsci.edu:asdf/core/table-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/table-1.0.0
+  title: A table.
+  description: |-
+    A table is represented as a list of columns, where each entry is a
+    [column](ref:core/column-1.0.0)
+    object, containing the data and some additional information.
+
+    The data itself may be stored inline as text, or in binary in either
+    row- or column-major order by use of the `strides` property on the
+    individual column arrays.
+
+    Each column in the table must have the same first (slowest moving)
+    dimension.
+- tag_uri: tag:stsci.edu:asdf/fits/fits-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/fits/fits-1.0.0
+  title: A FITS file inside of an ASDF file.
+  description: |-
+    This schema is useful for distributing ASDF files that can
+    automatically be converted to FITS files by specifying the exact
+    content of the resulting FITS file.
+
+    Not all kinds of data in FITS are directly representable in ASDF.
+    For example, applying an offset and scale to the data using the
+    `BZERO` and `BSCALE` keywords.  In these cases, it will not be
+    possible to store the data in the native format from FITS and also
+    be accessible in its proper form in the ASDF file.
+
+    Only image and binary table extensions are supported.
+- tag_uri: tag:stsci.edu:asdf/time/time-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/time/time-1.0.0
+  title: Represents an instance in time.
+  description: |-
+    A "time" is a single instant in time.  It may explicitly specify the
+    way time is represented (the "format") and the "scale" which
+    specifies the offset and scaling relation of the unit of time.
+
+    Specific emphasis is placed on supporting time scales (e.g. UTC,
+    TAI, UT1, TDB) and time representations (e.g. JD, MJD, ISO 8601)
+    that are used in astronomy and required to calculate, e.g., sidereal
+    times and barycentric corrections.
+
+    Times may be represented as one of the following:
+
+    - an object, with explicit `value`, and optional `format`, `scale`
+      and `location`.
+
+    - a string, in which case the format is guessed from across
+      the unambiguous options (`iso`, `byear`, `jyear`, `yday`), and the
+      scale is hardcoded to `UTC`.
+
+    In either case, a single time tag may be used to represent an
+    n-dimensional array of times, using either an `ndarray` tag or
+    inline as (possibly nested) YAML lists.  If YAML lists, the same
+    format must be used for all time values.
+
+    The precision of the numeric formats should only be assumed to be as
+    good as an IEEE-754 double precision (float64) value.  If
+    higher-precision is required, the `iso` or `yday` format should be
+    used.
+- tag_uri: tag:stsci.edu:asdf/unit/defunit-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/defunit-1.0.0
+  title: Define a new physical unit.
+  description: |-
+    Defines a new unit.  It can be used to either:
+
+    - Define a new base unit.
+
+    - Create a new unit name that is a equivalent to a given unit.
+
+    The new unit must be defined before any unit tags that use it.
+- tag_uri: tag:stsci.edu:asdf/unit/unit-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
+  title: Physical unit.
+  description: |-
+    This represents a physical unit, in [VOUnit syntax, Version 1.0](http://www.ivoa.net/documents/VOUnits/index.html).
+    Where units are not explicitly tagged, they are assumed to be in VOUnit syntax.
+- tag_uri: tag:stsci.edu:asdf/wcs/celestial_frame-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/celestial_frame-1.0.0
+  title: Represents a celestial frame.
+  description: Represents a celestial frame.
+- tag_uri: tag:stsci.edu:asdf/wcs/composite_frame-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/composite_frame-1.0.0
+  title: Represents a set of frames.
+  description: Represents a set of frames.
+- tag_uri: tag:stsci.edu:asdf/wcs/spectral_frame-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/spectral_frame-1.0.0
+  title: Represents a spectral frame.
+  description: Represents a spectral frame.
+- tag_uri: tag:stsci.edu:asdf/wcs/step-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/step-1.0.0
+  title: Describes a single step of a WCS transform pipeline.
+  description: Describes a single step of a WCS transform pipeline.
+- tag_uri: tag:stsci.edu:asdf/wcs/wcs-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/wcs-1.0.0
+  title: A system for describing generalized world coordinate transformations.
+  description: ASDF WCS is a way of specifying transformations (usually from detector
+    space to world coordinate space and back) by using the transformations in the
+    `transform-schema` module.

--- a/resources/asdf-format.org/core/manifests/core-1.1.0.yaml
+++ b/resources/asdf-format.org/core/manifests/core-1.1.0.yaml
@@ -1,0 +1,185 @@
+id: asdf://asdf-format.org/core/manifests/core-1.1.0
+extension_uri: asdf://asdf-format.org/core/extensions/core-1.1.0
+title: Core extension 1.1.0
+description: Tags for ASDF core objects.
+asdf_standard_requirement: 1.1.0
+tags:
+- tag_uri: tag:stsci.edu:asdf/core/asdf-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/asdf-1.0.0
+  title: Top-level schema for every ASDF file.
+  description: This schema contains the top-level attributes for every ASDF file.
+- tag_uri: tag:stsci.edu:asdf/core/column-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/column-1.0.0
+  title: A column in a table.
+  description: |-
+    Each column contains a name and an array of data, and an optional description
+    and unit.
+- tag_uri: tag:stsci.edu:asdf/core/complex-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/complex-1.0.0
+  title: Complex number value.
+  description: |-
+    Represents a complex number matching the following EBNF grammar
+
+    ```
+      dot           = "."
+      plus-or-minus = "+" | "-"
+      digit         = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+      sign          = "" | plus-or-minus
+      suffix        = "J" | "j" | "I" | "i"
+      inf           = "inf" | "INF"
+      nan           = "nan" | "NAN"
+      number        = digits | dot digits | digits dot digits
+      sci-suffix    = "e" | "E"
+      scientific    = number sci-suffix sign digits
+      real          = sign number | sign scientific
+      imag          = number suffix | scientific suffix
+      complex       = real | sign imag | real plus-or-minus imag
+    ```
+
+    Though `J`, `j`, `I` and `i` must be supported on reading, it is
+    recommended to use `i` on writing.
+
+    For historical reasons, it is necessary to accept as valid complex numbers
+    that are surrounded by parenthesis.
+- tag_uri: tag:stsci.edu:asdf/core/constant-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/constant-1.0.0
+  title: Specify that a value is a constant.
+  description: Used as a utility to indicate that value is a literal constant.
+- tag_uri: tag:stsci.edu:asdf/core/history_entry-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/history_entry-1.0.0
+  title: An entry in the file history.
+  description: |-
+    A record of an operation that has been performed
+    upon a file.
+- tag_uri: tag:stsci.edu:asdf/core/ndarray-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+  title: An *n*-dimensional array.
+  description: |-
+    There are two ways to store the data in an ndarray.
+
+    - Inline in the tree: This is recommended only for small arrays.  In
+      this case, the entire ``ndarray`` tag may be a nested list, in
+      which case the type of the array is inferred from the content.
+      (See the rules for type inference in the ``inline-data``
+      definition below.)  The inline data may also be given in the
+      ``data`` property, in which case it is possible to explicitly
+      specify the ``datatype`` and other properties.
+
+    - External to the tree: The data comes from a [block](ref:block)
+      within the same ASDF file or an external ASDF file referenced by a
+      URI.
+- tag_uri: tag:stsci.edu:asdf/core/software-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/software-1.0.0
+  title: Describes a software package.
+  description: General-purpose description of a software package.
+- tag_uri: tag:stsci.edu:asdf/core/table-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/table-1.0.0
+  title: A table.
+  description: |-
+    A table is represented as a list of columns, where each entry is a
+    [column](ref:core/column-1.0.0)
+    object, containing the data and some additional information.
+
+    The data itself may be stored inline as text, or in binary in either
+    row- or column-major order by use of the `strides` property on the
+    individual column arrays.
+
+    Each column in the table must have the same first (slowest moving)
+    dimension.
+- tag_uri: tag:stsci.edu:asdf/fits/fits-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/fits/fits-1.0.0
+  title: A FITS file inside of an ASDF file.
+  description: |-
+    This schema is useful for distributing ASDF files that can
+    automatically be converted to FITS files by specifying the exact
+    content of the resulting FITS file.
+
+    Not all kinds of data in FITS are directly representable in ASDF.
+    For example, applying an offset and scale to the data using the
+    `BZERO` and `BSCALE` keywords.  In these cases, it will not be
+    possible to store the data in the native format from FITS and also
+    be accessible in its proper form in the ASDF file.
+
+    Only image and binary table extensions are supported.
+- tag_uri: tag:stsci.edu:asdf/time/time-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/time/time-1.1.0
+  title: Represents an instance in time.
+  description: |-
+    A "time" is a single instant in time.  It may explicitly specify the
+    way time is represented (the "format") and the "scale" which
+    specifies the offset and scaling relation of the unit of time.
+
+    Specific emphasis is placed on supporting time scales (e.g. UTC,
+    TAI, UT1, TDB) and time representations (e.g. JD, MJD, ISO 8601)
+    that are used in astronomy and required to calculate, e.g., sidereal
+    times and barycentric corrections.
+
+    Times may be represented as one of the following:
+
+    - an object, with explicit `value`, and optional `format`, `scale`
+      and `location`.
+
+    - a string, in which case the format is guessed from across
+      the unambiguous options (`iso`, `byear`, `jyear`, `yday`), and the
+      scale is hardcoded to `UTC`.
+
+    In either case, a single time tag may be used to represent an
+    n-dimensional array of times, using either an `ndarray` tag or
+    inline as (possibly nested) YAML lists.  If YAML lists, the same
+    format must be used for all time values.
+
+    The precision of the numeric formats should only be assumed to be as
+    good as an IEEE-754 double precision (float64) value.  If
+    higher-precision is required, the `iso` or `yday` format should be
+    used.
+- tag_uri: tag:stsci.edu:asdf/unit/defunit-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/defunit-1.0.0
+  title: Define a new physical unit.
+  description: |-
+    Defines a new unit.  It can be used to either:
+
+    - Define a new base unit.
+
+    - Create a new unit name that is a equivalent to a given unit.
+
+    The new unit must be defined before any unit tags that use it.
+- tag_uri: tag:stsci.edu:asdf/unit/quantity-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/quantity-1.1.0
+  title: Represents a Quantity object from astropy
+  description: |-
+    A Quantity object represents a value that has some unit
+    associated with the number.
+- tag_uri: tag:stsci.edu:asdf/unit/unit-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
+  title: Physical unit.
+  description: |-
+    This represents a physical unit, in [VOUnit syntax, Version 1.0](http://www.ivoa.net/documents/VOUnits/index.html).
+    Where units are not explicitly tagged, they are assumed to be in VOUnit syntax.
+- tag_uri: tag:stsci.edu:asdf/wcs/celestial_frame-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/celestial_frame-1.1.0
+  title: Represents a celestial frame.
+  description: Represents a celestial frame.
+- tag_uri: tag:stsci.edu:asdf/wcs/composite_frame-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/composite_frame-1.1.0
+  title: Represents a set of frames.
+  description: Represents a set of frames.
+- tag_uri: tag:stsci.edu:asdf/wcs/icrs_coord-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/icrs_coord-1.1.0
+  title: Represents an ICRS coordinate object from astropy
+  description: This object represents the right ascension (RA) and declination of
+    an ICRS coordinate or frame. The astropy ICRS class contains additional fields
+    that may be useful to add here in the future.
+- tag_uri: tag:stsci.edu:asdf/wcs/spectral_frame-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/spectral_frame-1.1.0
+  title: Represents a spectral frame.
+  description: Represents a spectral frame.
+- tag_uri: tag:stsci.edu:asdf/wcs/step-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/step-1.1.0
+  title: Describes a single step of a WCS transform pipeline.
+  description: Describes a single step of a WCS transform pipeline.
+- tag_uri: tag:stsci.edu:asdf/wcs/wcs-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/wcs-1.0.0
+  title: A system for describing generalized world coordinate transformations.
+  description: ASDF WCS is a way of specifying transformations (usually from detector
+    space to world coordinate space and back) by using the transformations in the
+    `transform-schema` module.

--- a/resources/asdf-format.org/core/manifests/core-1.2.0.yaml
+++ b/resources/asdf-format.org/core/manifests/core-1.2.0.yaml
@@ -1,0 +1,185 @@
+id: asdf://asdf-format.org/core/manifests/core-1.2.0
+extension_uri: asdf://asdf-format.org/core/extensions/core-1.2.0
+title: Core extension 1.2.0
+description: Tags for ASDF core objects.
+asdf_standard_requirement: 1.2.0
+tags:
+- tag_uri: tag:stsci.edu:asdf/core/asdf-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/asdf-1.1.0
+  title: Top-level schema for every ASDF file.
+  description: This schema contains the top-level attributes for every ASDF file.
+- tag_uri: tag:stsci.edu:asdf/core/column-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/column-1.0.0
+  title: A column in a table.
+  description: |-
+    Each column contains a name and an array of data, and an optional description
+    and unit.
+- tag_uri: tag:stsci.edu:asdf/core/complex-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/complex-1.0.0
+  title: Complex number value.
+  description: |-
+    Represents a complex number matching the following EBNF grammar
+
+    ```
+      dot           = "."
+      plus-or-minus = "+" | "-"
+      digit         = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+      sign          = "" | plus-or-minus
+      suffix        = "J" | "j" | "I" | "i"
+      inf           = "inf" | "INF"
+      nan           = "nan" | "NAN"
+      number        = digits | dot digits | digits dot digits
+      sci-suffix    = "e" | "E"
+      scientific    = number sci-suffix sign digits
+      real          = sign number | sign scientific
+      imag          = number suffix | scientific suffix
+      complex       = real | sign imag | real plus-or-minus imag
+    ```
+
+    Though `J`, `j`, `I` and `i` must be supported on reading, it is
+    recommended to use `i` on writing.
+
+    For historical reasons, it is necessary to accept as valid complex numbers
+    that are surrounded by parenthesis.
+- tag_uri: tag:stsci.edu:asdf/core/constant-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/constant-1.0.0
+  title: Specify that a value is a constant.
+  description: Used as a utility to indicate that value is a literal constant.
+- tag_uri: tag:stsci.edu:asdf/core/history_entry-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/history_entry-1.0.0
+  title: An entry in the file history.
+  description: |-
+    A record of an operation that has been performed
+    upon a file.
+- tag_uri: tag:stsci.edu:asdf/core/ndarray-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+  title: An *n*-dimensional array.
+  description: |-
+    There are two ways to store the data in an ndarray.
+
+    - Inline in the tree: This is recommended only for small arrays.  In
+      this case, the entire ``ndarray`` tag may be a nested list, in
+      which case the type of the array is inferred from the content.
+      (See the rules for type inference in the ``inline-data``
+      definition below.)  The inline data may also be given in the
+      ``data`` property, in which case it is possible to explicitly
+      specify the ``datatype`` and other properties.
+
+    - External to the tree: The data comes from a [block](ref:block)
+      within the same ASDF file or an external ASDF file referenced by a
+      URI.
+- tag_uri: tag:stsci.edu:asdf/core/software-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/software-1.0.0
+  title: Describes a software package.
+  description: General-purpose description of a software package.
+- tag_uri: tag:stsci.edu:asdf/core/table-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/table-1.0.0
+  title: A table.
+  description: |-
+    A table is represented as a list of columns, where each entry is a
+    [column](ref:core/column-1.0.0)
+    object, containing the data and some additional information.
+
+    The data itself may be stored inline as text, or in binary in either
+    row- or column-major order by use of the `strides` property on the
+    individual column arrays.
+
+    Each column in the table must have the same first (slowest moving)
+    dimension.
+- tag_uri: tag:stsci.edu:asdf/fits/fits-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/fits/fits-1.0.0
+  title: A FITS file inside of an ASDF file.
+  description: |-
+    This schema is useful for distributing ASDF files that can
+    automatically be converted to FITS files by specifying the exact
+    content of the resulting FITS file.
+
+    Not all kinds of data in FITS are directly representable in ASDF.
+    For example, applying an offset and scale to the data using the
+    `BZERO` and `BSCALE` keywords.  In these cases, it will not be
+    possible to store the data in the native format from FITS and also
+    be accessible in its proper form in the ASDF file.
+
+    Only image and binary table extensions are supported.
+- tag_uri: tag:stsci.edu:asdf/time/time-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/time/time-1.1.0
+  title: Represents an instance in time.
+  description: |-
+    A "time" is a single instant in time.  It may explicitly specify the
+    way time is represented (the "format") and the "scale" which
+    specifies the offset and scaling relation of the unit of time.
+
+    Specific emphasis is placed on supporting time scales (e.g. UTC,
+    TAI, UT1, TDB) and time representations (e.g. JD, MJD, ISO 8601)
+    that are used in astronomy and required to calculate, e.g., sidereal
+    times and barycentric corrections.
+
+    Times may be represented as one of the following:
+
+    - an object, with explicit `value`, and optional `format`, `scale`
+      and `location`.
+
+    - a string, in which case the format is guessed from across
+      the unambiguous options (`iso`, `byear`, `jyear`, `yday`), and the
+      scale is hardcoded to `UTC`.
+
+    In either case, a single time tag may be used to represent an
+    n-dimensional array of times, using either an `ndarray` tag or
+    inline as (possibly nested) YAML lists.  If YAML lists, the same
+    format must be used for all time values.
+
+    The precision of the numeric formats should only be assumed to be as
+    good as an IEEE-754 double precision (float64) value.  If
+    higher-precision is required, the `iso` or `yday` format should be
+    used.
+- tag_uri: tag:stsci.edu:asdf/unit/defunit-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/defunit-1.0.0
+  title: Define a new physical unit.
+  description: |-
+    Defines a new unit.  It can be used to either:
+
+    - Define a new base unit.
+
+    - Create a new unit name that is a equivalent to a given unit.
+
+    The new unit must be defined before any unit tags that use it.
+- tag_uri: tag:stsci.edu:asdf/unit/quantity-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/quantity-1.1.0
+  title: Represents a Quantity object from astropy
+  description: |-
+    A Quantity object represents a value that has some unit
+    associated with the number.
+- tag_uri: tag:stsci.edu:asdf/unit/unit-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
+  title: Physical unit.
+  description: |-
+    This represents a physical unit, in [VOUnit syntax, Version 1.0](http://www.ivoa.net/documents/VOUnits/index.html).
+    Where units are not explicitly tagged, they are assumed to be in VOUnit syntax.
+- tag_uri: tag:stsci.edu:asdf/wcs/celestial_frame-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/celestial_frame-1.1.0
+  title: Represents a celestial frame.
+  description: Represents a celestial frame.
+- tag_uri: tag:stsci.edu:asdf/wcs/composite_frame-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/composite_frame-1.1.0
+  title: Represents a set of frames.
+  description: Represents a set of frames.
+- tag_uri: tag:stsci.edu:asdf/wcs/icrs_coord-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/icrs_coord-1.1.0
+  title: Represents an ICRS coordinate object from astropy
+  description: This object represents the right ascension (RA) and declination of
+    an ICRS coordinate or frame. The astropy ICRS class contains additional fields
+    that may be useful to add here in the future.
+- tag_uri: tag:stsci.edu:asdf/wcs/spectral_frame-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/spectral_frame-1.1.0
+  title: Represents a spectral frame.
+  description: Represents a spectral frame.
+- tag_uri: tag:stsci.edu:asdf/wcs/step-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/step-1.1.0
+  title: Describes a single step of a WCS transform pipeline.
+  description: Describes a single step of a WCS transform pipeline.
+- tag_uri: tag:stsci.edu:asdf/wcs/wcs-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/wcs-1.1.0
+  title: A system for describing generalized world coordinate transformations.
+  description: ASDF WCS is a way of specifying transformations (usually from detector
+    space to world coordinate space and back) by using the transformations in the
+    `transform-schema` module.

--- a/resources/asdf-format.org/core/manifests/core-1.3.0.yaml
+++ b/resources/asdf-format.org/core/manifests/core-1.3.0.yaml
@@ -1,0 +1,196 @@
+id: asdf://asdf-format.org/core/manifests/core-1.3.0
+extension_uri: asdf://asdf-format.org/core/extensions/core-1.3.0
+title: Core extension 1.3.0
+description: Tags for ASDF core objects.
+asdf_standard_requirement: 1.3.0
+tags:
+- tag_uri: tag:stsci.edu:asdf/core/asdf-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/asdf-1.1.0
+  title: Top-level schema for every ASDF file.
+  description: This schema contains the top-level attributes for every ASDF file.
+- tag_uri: tag:stsci.edu:asdf/core/column-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/column-1.0.0
+  title: A column in a table.
+  description: |-
+    Each column contains a name and an array of data, and an optional description
+    and unit.
+- tag_uri: tag:stsci.edu:asdf/core/complex-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/complex-1.0.0
+  title: Complex number value.
+  description: |-
+    Represents a complex number matching the following EBNF grammar
+
+    ```
+      dot           = "."
+      plus-or-minus = "+" | "-"
+      digit         = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+      sign          = "" | plus-or-minus
+      suffix        = "J" | "j" | "I" | "i"
+      inf           = "inf" | "INF"
+      nan           = "nan" | "NAN"
+      number        = digits | dot digits | digits dot digits
+      sci-suffix    = "e" | "E"
+      scientific    = number sci-suffix sign digits
+      real          = sign number | sign scientific
+      imag          = number suffix | scientific suffix
+      complex       = real | sign imag | real plus-or-minus imag
+    ```
+
+    Though `J`, `j`, `I` and `i` must be supported on reading, it is
+    recommended to use `i` on writing.
+
+    For historical reasons, it is necessary to accept as valid complex numbers
+    that are surrounded by parenthesis.
+- tag_uri: tag:stsci.edu:asdf/core/constant-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/constant-1.0.0
+  title: Specify that a value is a constant.
+  description: Used as a utility to indicate that value is a literal constant.
+- tag_uri: tag:stsci.edu:asdf/core/externalarray-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/externalarray-1.0.0
+  title: Point to an array-like object in an external file.
+  description: |-
+    Allow referencing of array-like objects in external files. These files can be
+    any type of file and in any absolute or relative location to the asdf file.
+    Loading of these files into arrays is not handled by asdf.
+- tag_uri: tag:stsci.edu:asdf/core/history_entry-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/history_entry-1.0.0
+  title: An entry in the file history.
+  description: |-
+    A record of an operation that has been performed
+    upon a file.
+- tag_uri: tag:stsci.edu:asdf/core/integer-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/integer-1.0.0
+  title: Arbitrary precision integer value.
+  description: Represents an arbitrarily large integer value.
+- tag_uri: tag:stsci.edu:asdf/core/ndarray-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+  title: An *n*-dimensional array.
+  description: |-
+    There are two ways to store the data in an ndarray.
+
+    - Inline in the tree: This is recommended only for small arrays.  In
+      this case, the entire ``ndarray`` tag may be a nested list, in
+      which case the type of the array is inferred from the content.
+      (See the rules for type inference in the ``inline-data``
+      definition below.)  The inline data may also be given in the
+      ``data`` property, in which case it is possible to explicitly
+      specify the ``datatype`` and other properties.
+
+    - External to the tree: The data comes from a [block](ref:block)
+      within the same ASDF file or an external ASDF file referenced by a
+      URI.
+- tag_uri: tag:stsci.edu:asdf/core/software-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/software-1.0.0
+  title: Describes a software package.
+  description: General-purpose description of a software package.
+- tag_uri: tag:stsci.edu:asdf/core/table-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/table-1.0.0
+  title: A table.
+  description: |-
+    A table is represented as a list of columns, where each entry is a
+    [column](ref:core/column-1.0.0)
+    object, containing the data and some additional information.
+
+    The data itself may be stored inline as text, or in binary in either
+    row- or column-major order by use of the `strides` property on the
+    individual column arrays.
+
+    Each column in the table must have the same first (slowest moving)
+    dimension.
+- tag_uri: tag:stsci.edu:asdf/fits/fits-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/fits/fits-1.0.0
+  title: A FITS file inside of an ASDF file.
+  description: |-
+    This schema is useful for distributing ASDF files that can
+    automatically be converted to FITS files by specifying the exact
+    content of the resulting FITS file.
+
+    Not all kinds of data in FITS are directly representable in ASDF.
+    For example, applying an offset and scale to the data using the
+    `BZERO` and `BSCALE` keywords.  In these cases, it will not be
+    possible to store the data in the native format from FITS and also
+    be accessible in its proper form in the ASDF file.
+
+    Only image and binary table extensions are supported.
+- tag_uri: tag:stsci.edu:asdf/time/time-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/time/time-1.1.0
+  title: Represents an instance in time.
+  description: |-
+    A "time" is a single instant in time.  It may explicitly specify the
+    way time is represented (the "format") and the "scale" which
+    specifies the offset and scaling relation of the unit of time.
+
+    Specific emphasis is placed on supporting time scales (e.g. UTC,
+    TAI, UT1, TDB) and time representations (e.g. JD, MJD, ISO 8601)
+    that are used in astronomy and required to calculate, e.g., sidereal
+    times and barycentric corrections.
+
+    Times may be represented as one of the following:
+
+    - an object, with explicit `value`, and optional `format`, `scale`
+      and `location`.
+
+    - a string, in which case the format is guessed from across
+      the unambiguous options (`iso`, `byear`, `jyear`, `yday`), and the
+      scale is hardcoded to `UTC`.
+
+    In either case, a single time tag may be used to represent an
+    n-dimensional array of times, using either an `ndarray` tag or
+    inline as (possibly nested) YAML lists.  If YAML lists, the same
+    format must be used for all time values.
+
+    The precision of the numeric formats should only be assumed to be as
+    good as an IEEE-754 double precision (float64) value.  If
+    higher-precision is required, the `iso` or `yday` format should be
+    used.
+- tag_uri: tag:stsci.edu:asdf/unit/defunit-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/defunit-1.0.0
+  title: Define a new physical unit.
+  description: |-
+    Defines a new unit.  It can be used to either:
+
+    - Define a new base unit.
+
+    - Create a new unit name that is a equivalent to a given unit.
+
+    The new unit must be defined before any unit tags that use it.
+- tag_uri: tag:stsci.edu:asdf/unit/quantity-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/quantity-1.1.0
+  title: Represents a Quantity object from astropy
+  description: |-
+    A Quantity object represents a value that has some unit
+    associated with the number.
+- tag_uri: tag:stsci.edu:asdf/unit/unit-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
+  title: Physical unit.
+  description: |-
+    This represents a physical unit, in [VOUnit syntax, Version 1.0](http://www.ivoa.net/documents/VOUnits/index.html).
+    Where units are not explicitly tagged, they are assumed to be in VOUnit syntax.
+- tag_uri: tag:stsci.edu:asdf/wcs/celestial_frame-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/celestial_frame-1.1.0
+  title: Represents a celestial frame.
+  description: Represents a celestial frame.
+- tag_uri: tag:stsci.edu:asdf/wcs/composite_frame-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/composite_frame-1.1.0
+  title: Represents a set of frames.
+  description: Represents a set of frames.
+- tag_uri: tag:stsci.edu:asdf/wcs/icrs_coord-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/icrs_coord-1.1.0
+  title: Represents an ICRS coordinate object from astropy
+  description: This object represents the right ascension (RA) and declination of
+    an ICRS coordinate or frame. The astropy ICRS class contains additional fields
+    that may be useful to add here in the future.
+- tag_uri: tag:stsci.edu:asdf/wcs/spectral_frame-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/spectral_frame-1.1.0
+  title: Represents a spectral frame.
+  description: Represents a spectral frame.
+- tag_uri: tag:stsci.edu:asdf/wcs/step-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/step-1.1.0
+  title: Describes a single step of a WCS transform pipeline.
+  description: Describes a single step of a WCS transform pipeline.
+- tag_uri: tag:stsci.edu:asdf/wcs/wcs-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/wcs-1.1.0
+  title: A system for describing generalized world coordinate transformations.
+  description: ASDF WCS is a way of specifying transformations (usually from detector
+    space to world coordinate space and back) by using the transformations in the
+    `transform-schema` module.

--- a/resources/asdf-format.org/core/manifests/core-1.4.0.yaml
+++ b/resources/asdf-format.org/core/manifests/core-1.4.0.yaml
@@ -1,0 +1,207 @@
+id: asdf://asdf-format.org/core/manifests/core-1.4.0
+extension_uri: asdf://asdf-format.org/core/extensions/core-1.4.0
+title: Core extension 1.4.0
+description: Tags for ASDF core objects.
+asdf_standard_requirement: 1.4.0
+tags:
+- tag_uri: tag:stsci.edu:asdf/core/asdf-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/asdf-1.1.0
+  title: Top-level schema for every ASDF file.
+  description: This schema contains the top-level attributes for every ASDF file.
+- tag_uri: tag:stsci.edu:asdf/core/column-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/column-1.0.0
+  title: A column in a table.
+  description: |-
+    Each column contains a name and an array of data, and an optional description
+    and unit.
+- tag_uri: tag:stsci.edu:asdf/core/complex-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/complex-1.0.0
+  title: Complex number value.
+  description: |-
+    Represents a complex number matching the following EBNF grammar
+
+    ```
+      dot           = "."
+      plus-or-minus = "+" | "-"
+      digit         = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+      sign          = "" | plus-or-minus
+      suffix        = "J" | "j" | "I" | "i"
+      inf           = "inf" | "INF"
+      nan           = "nan" | "NAN"
+      number        = digits | dot digits | digits dot digits
+      sci-suffix    = "e" | "E"
+      scientific    = number sci-suffix sign digits
+      real          = sign number | sign scientific
+      imag          = number suffix | scientific suffix
+      complex       = real | sign imag | real plus-or-minus imag
+    ```
+
+    Though `J`, `j`, `I` and `i` must be supported on reading, it is
+    recommended to use `i` on writing.
+
+    For historical reasons, it is necessary to accept as valid complex numbers
+    that are surrounded by parenthesis.
+- tag_uri: tag:stsci.edu:asdf/core/constant-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/constant-1.0.0
+  title: Specify that a value is a constant.
+  description: Used as a utility to indicate that value is a literal constant.
+- tag_uri: tag:stsci.edu:asdf/core/extension_metadata-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/extension_metadata-1.0.0
+  title: Metadata about specific ASDF extensions that were used to create this file.
+  description: Metadata about specific ASDF extensions that were used to create this
+    file.
+- tag_uri: tag:stsci.edu:asdf/core/externalarray-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/externalarray-1.0.0
+  title: Point to an array-like object in an external file.
+  description: |-
+    Allow referencing of array-like objects in external files. These files can be
+    any type of file and in any absolute or relative location to the asdf file.
+    Loading of these files into arrays is not handled by asdf.
+- tag_uri: tag:stsci.edu:asdf/core/history_entry-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/history_entry-1.0.0
+  title: An entry in the file history.
+  description: |-
+    A record of an operation that has been performed
+    upon a file.
+- tag_uri: tag:stsci.edu:asdf/core/integer-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/integer-1.0.0
+  title: Arbitrary precision integer value.
+  description: Represents an arbitrarily large integer value.
+- tag_uri: tag:stsci.edu:asdf/core/ndarray-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+  title: An *n*-dimensional array.
+  description: |-
+    There are two ways to store the data in an ndarray.
+
+    - Inline in the tree: This is recommended only for small arrays.  In
+      this case, the entire ``ndarray`` tag may be a nested list, in
+      which case the type of the array is inferred from the content.
+      (See the rules for type inference in the ``inline-data``
+      definition below.)  The inline data may also be given in the
+      ``data`` property, in which case it is possible to explicitly
+      specify the ``datatype`` and other properties.
+
+    - External to the tree: The data comes from a [block](ref:block)
+      within the same ASDF file or an external ASDF file referenced by a
+      URI.
+- tag_uri: tag:stsci.edu:asdf/core/software-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/software-1.0.0
+  title: Describes a software package.
+  description: General-purpose description of a software package.
+- tag_uri: tag:stsci.edu:asdf/core/subclass_metadata-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/subclass_metadata-1.0.0
+  title: Metadata on a serialized subclass of an ASDF-enabled type.
+  description: |-
+    Identifies the specific subclass that was serialized,
+    to enable ASDF readers to correctly deserialize the object.
+- tag_uri: tag:stsci.edu:asdf/core/table-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/table-1.0.0
+  title: A table.
+  description: |-
+    A table is represented as a list of columns, where each entry is a
+    [column](ref:core/column-1.0.0)
+    object, containing the data and some additional information.
+
+    The data itself may be stored inline as text, or in binary in either
+    row- or column-major order by use of the `strides` property on the
+    individual column arrays.
+
+    Each column in the table must have the same first (slowest moving)
+    dimension.
+- tag_uri: tag:stsci.edu:asdf/fits/fits-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/fits/fits-1.0.0
+  title: A FITS file inside of an ASDF file.
+  description: |-
+    This schema is useful for distributing ASDF files that can
+    automatically be converted to FITS files by specifying the exact
+    content of the resulting FITS file.
+
+    Not all kinds of data in FITS are directly representable in ASDF.
+    For example, applying an offset and scale to the data using the
+    `BZERO` and `BSCALE` keywords.  In these cases, it will not be
+    possible to store the data in the native format from FITS and also
+    be accessible in its proper form in the ASDF file.
+
+    Only image and binary table extensions are supported.
+- tag_uri: tag:stsci.edu:asdf/time/time-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/time/time-1.1.0
+  title: Represents an instance in time.
+  description: |-
+    A "time" is a single instant in time.  It may explicitly specify the
+    way time is represented (the "format") and the "scale" which
+    specifies the offset and scaling relation of the unit of time.
+
+    Specific emphasis is placed on supporting time scales (e.g. UTC,
+    TAI, UT1, TDB) and time representations (e.g. JD, MJD, ISO 8601)
+    that are used in astronomy and required to calculate, e.g., sidereal
+    times and barycentric corrections.
+
+    Times may be represented as one of the following:
+
+    - an object, with explicit `value`, and optional `format`, `scale`
+      and `location`.
+
+    - a string, in which case the format is guessed from across
+      the unambiguous options (`iso`, `byear`, `jyear`, `yday`), and the
+      scale is hardcoded to `UTC`.
+
+    In either case, a single time tag may be used to represent an
+    n-dimensional array of times, using either an `ndarray` tag or
+    inline as (possibly nested) YAML lists.  If YAML lists, the same
+    format must be used for all time values.
+
+    The precision of the numeric formats should only be assumed to be as
+    good as an IEEE-754 double precision (float64) value.  If
+    higher-precision is required, the `iso` or `yday` format should be
+    used.
+- tag_uri: tag:stsci.edu:asdf/unit/defunit-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/defunit-1.0.0
+  title: Define a new physical unit.
+  description: |-
+    Defines a new unit.  It can be used to either:
+
+    - Define a new base unit.
+
+    - Create a new unit name that is a equivalent to a given unit.
+
+    The new unit must be defined before any unit tags that use it.
+- tag_uri: tag:stsci.edu:asdf/unit/quantity-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/quantity-1.1.0
+  title: Represents a Quantity object from astropy
+  description: |-
+    A Quantity object represents a value that has some unit
+    associated with the number.
+- tag_uri: tag:stsci.edu:asdf/unit/unit-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
+  title: Physical unit.
+  description: |-
+    This represents a physical unit, in [VOUnit syntax, Version 1.0](http://www.ivoa.net/documents/VOUnits/index.html).
+    Where units are not explicitly tagged, they are assumed to be in VOUnit syntax.
+- tag_uri: tag:stsci.edu:asdf/wcs/celestial_frame-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/celestial_frame-1.1.0
+  title: Represents a celestial frame.
+  description: Represents a celestial frame.
+- tag_uri: tag:stsci.edu:asdf/wcs/composite_frame-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/composite_frame-1.1.0
+  title: Represents a set of frames.
+  description: Represents a set of frames.
+- tag_uri: tag:stsci.edu:asdf/wcs/icrs_coord-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/icrs_coord-1.1.0
+  title: Represents an ICRS coordinate object from astropy
+  description: This object represents the right ascension (RA) and declination of
+    an ICRS coordinate or frame. The astropy ICRS class contains additional fields
+    that may be useful to add here in the future.
+- tag_uri: tag:stsci.edu:asdf/wcs/spectral_frame-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/spectral_frame-1.1.0
+  title: Represents a spectral frame.
+  description: Represents a spectral frame.
+- tag_uri: tag:stsci.edu:asdf/wcs/step-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/step-1.2.0
+  title: Describes a single step of a WCS transform pipeline.
+  description: Describes a single step of a WCS transform pipeline.
+- tag_uri: tag:stsci.edu:asdf/wcs/wcs-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/wcs/wcs-1.2.0
+  title: A system for describing generalized world coordinate transformations.
+  description: ASDF WCS is a way of specifying transformations (usually from detector
+    space to world coordinate space and back) by using the transformations in the
+    `transform-schema` module.

--- a/resources/asdf-format.org/core/manifests/core-1.5.0.yaml
+++ b/resources/asdf-format.org/core/manifests/core-1.5.0.yaml
@@ -1,0 +1,179 @@
+id: asdf://asdf-format.org/core/manifests/core-1.5.0
+extension_uri: asdf://asdf-format.org/core/extensions/core-1.5.0
+title: Core extension 1.5.0
+description: Tags for ASDF core objects.
+asdf_standard_requirement: 1.5.0
+tags:
+- tag_uri: tag:stsci.edu:asdf/core/asdf-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/asdf-1.1.0
+  title: Top-level schema for every ASDF file.
+  description: This schema contains the top-level attributes for every ASDF file.
+- tag_uri: tag:stsci.edu:asdf/core/column-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/column-1.0.0
+  title: A column in a table.
+  description: |-
+    Each column contains a name and an array of data, and an optional description
+    and unit.
+- tag_uri: tag:stsci.edu:asdf/core/complex-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/complex-1.0.0
+  title: Complex number value.
+  description: |-
+    Represents a complex number matching the following EBNF grammar
+
+    ```
+      dot           = "."
+      plus-or-minus = "+" | "-"
+      digit         = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+      sign          = "" | plus-or-minus
+      suffix        = "J" | "j" | "I" | "i"
+      inf           = "inf" | "INF"
+      nan           = "nan" | "NAN"
+      number        = digits | dot digits | digits dot digits
+      sci-suffix    = "e" | "E"
+      scientific    = number sci-suffix sign digits
+      real          = sign number | sign scientific
+      imag          = number suffix | scientific suffix
+      complex       = real | sign imag | real plus-or-minus imag
+    ```
+
+    Though `J`, `j`, `I` and `i` must be supported on reading, it is
+    recommended to use `i` on writing.
+
+    For historical reasons, it is necessary to accept as valid complex numbers
+    that are surrounded by parenthesis.
+- tag_uri: tag:stsci.edu:asdf/core/constant-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/constant-1.0.0
+  title: Specify that a value is a constant.
+  description: Used as a utility to indicate that value is a literal constant.
+- tag_uri: tag:stsci.edu:asdf/core/extension_metadata-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/extension_metadata-1.0.0
+  title: Metadata about specific ASDF extensions that were used to create this file.
+  description: Metadata about specific ASDF extensions that were used to create this
+    file.
+- tag_uri: tag:stsci.edu:asdf/core/externalarray-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/externalarray-1.0.0
+  title: Point to an array-like object in an external file.
+  description: |-
+    Allow referencing of array-like objects in external files. These files can be
+    any type of file and in any absolute or relative location to the asdf file.
+    Loading of these files into arrays is not handled by asdf.
+- tag_uri: tag:stsci.edu:asdf/core/history_entry-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/history_entry-1.0.0
+  title: An entry in the file history.
+  description: |-
+    A record of an operation that has been performed
+    upon a file.
+- tag_uri: tag:stsci.edu:asdf/core/integer-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/integer-1.0.0
+  title: Arbitrary precision integer value.
+  description: Represents an arbitrarily large integer value.
+- tag_uri: tag:stsci.edu:asdf/core/ndarray-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+  title: An *n*-dimensional array.
+  description: |-
+    There are two ways to store the data in an ndarray.
+
+    - Inline in the tree: This is recommended only for small arrays.  In
+      this case, the entire ``ndarray`` tag may be a nested list, in
+      which case the type of the array is inferred from the content.
+      (See the rules for type inference in the ``inline-data``
+      definition below.)  The inline data may also be given in the
+      ``data`` property, in which case it is possible to explicitly
+      specify the ``datatype`` and other properties.
+
+    - External to the tree: The data comes from a [block](ref:block)
+      within the same ASDF file or an external ASDF file referenced by a
+      URI.
+- tag_uri: tag:stsci.edu:asdf/core/software-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/software-1.0.0
+  title: Describes a software package.
+  description: General-purpose description of a software package.
+- tag_uri: tag:stsci.edu:asdf/core/subclass_metadata-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/subclass_metadata-1.0.0
+  title: Metadata on a serialized subclass of an ASDF-enabled type.
+  description: |-
+    Identifies the specific subclass that was serialized,
+    to enable ASDF readers to correctly deserialize the object.
+- tag_uri: tag:stsci.edu:asdf/core/table-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/table-1.0.0
+  title: A table.
+  description: |-
+    A table is represented as a list of columns, where each entry is a
+    [column](ref:core/column-1.0.0)
+    object, containing the data and some additional information.
+
+    The data itself may be stored inline as text, or in binary in either
+    row- or column-major order by use of the `strides` property on the
+    individual column arrays.
+
+    Each column in the table must have the same first (slowest moving)
+    dimension.
+- tag_uri: tag:stsci.edu:asdf/fits/fits-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/fits/fits-1.0.0
+  title: A FITS file inside of an ASDF file.
+  description: |-
+    This schema is useful for distributing ASDF files that can
+    automatically be converted to FITS files by specifying the exact
+    content of the resulting FITS file.
+
+    Not all kinds of data in FITS are directly representable in ASDF.
+    For example, applying an offset and scale to the data using the
+    `BZERO` and `BSCALE` keywords.  In these cases, it will not be
+    possible to store the data in the native format from FITS and also
+    be accessible in its proper form in the ASDF file.
+
+    Only image and binary table extensions are supported.
+- tag_uri: tag:stsci.edu:asdf/time/time-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/time/time-1.1.0
+  title: Represents an instance in time.
+  description: |-
+    A "time" is a single instant in time.  It may explicitly specify the
+    way time is represented (the "format") and the "scale" which
+    specifies the offset and scaling relation of the unit of time.
+
+    Specific emphasis is placed on supporting time scales (e.g. UTC,
+    TAI, UT1, TDB) and time representations (e.g. JD, MJD, ISO 8601)
+    that are used in astronomy and required to calculate, e.g., sidereal
+    times and barycentric corrections.
+
+    Times may be represented as one of the following:
+
+    - an object, with explicit `value`, and optional `format`, `scale`
+      and `location`.
+
+    - a string, in which case the format is guessed from across
+      the unambiguous options (`iso`, `byear`, `jyear`, `yday`), and the
+      scale is hardcoded to `UTC`.
+
+    In either case, a single time tag may be used to represent an
+    n-dimensional array of times, using either an `ndarray` tag or
+    inline as (possibly nested) YAML lists.  If YAML lists, the same
+    format must be used for all time values.
+
+    The precision of the numeric formats should only be assumed to be as
+    good as an IEEE-754 double precision (float64) value.  If
+    higher-precision is required, the `iso` or `yday` format should be
+    used.
+- tag_uri: tag:stsci.edu:asdf/unit/defunit-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/defunit-1.0.0
+  title: Define a new physical unit.
+  description: |-
+    Defines a new unit.  It can be used to either:
+
+    - Define a new base unit.
+
+    - Create a new unit name that is a equivalent to a given unit.
+
+    The new unit must be defined before any unit tags that use it.
+- tag_uri: tag:stsci.edu:asdf/unit/quantity-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/quantity-1.1.0
+  title: Represents a Quantity object from astropy
+  description: |-
+    A Quantity object represents a value that has some unit
+    associated with the number.
+- tag_uri: tag:stsci.edu:asdf/unit/unit-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
+  title: Physical unit.
+  description: |-
+    This represents a physical unit, in [VOUnit syntax, Version 1.0](http://www.ivoa.net/documents/VOUnits/index.html).
+    Where units are not explicitly tagged, they are assumed to be in VOUnit syntax.

--- a/resources/asdf-format.org/core/manifests/core-1.6.0.yaml
+++ b/resources/asdf-format.org/core/manifests/core-1.6.0.yaml
@@ -1,0 +1,179 @@
+id: asdf://asdf-format.org/core/manifests/core-1.6.0
+extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+title: Core extension 1.6.0
+description: Tags for ASDF core objects.
+asdf_standard_requirement: 1.6.0
+tags:
+- tag_uri: tag:stsci.edu:asdf/core/asdf-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/asdf-1.1.0
+  title: Top-level schema for every ASDF file.
+  description: This schema contains the top-level attributes for every ASDF file.
+- tag_uri: tag:stsci.edu:asdf/core/column-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/column-1.0.0
+  title: A column in a table.
+  description: |-
+    Each column contains a name and an array of data, and an optional description
+    and unit.
+- tag_uri: tag:stsci.edu:asdf/core/complex-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/complex-1.0.0
+  title: Complex number value.
+  description: |-
+    Represents a complex number matching the following EBNF grammar
+
+    ```
+      dot           = "."
+      plus-or-minus = "+" | "-"
+      digit         = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+      sign          = "" | plus-or-minus
+      suffix        = "J" | "j" | "I" | "i"
+      inf           = "inf" | "INF"
+      nan           = "nan" | "NAN"
+      number        = digits | dot digits | digits dot digits
+      sci-suffix    = "e" | "E"
+      scientific    = number sci-suffix sign digits
+      real          = sign number | sign scientific
+      imag          = number suffix | scientific suffix
+      complex       = real | sign imag | real plus-or-minus imag
+    ```
+
+    Though `J`, `j`, `I` and `i` must be supported on reading, it is
+    recommended to use `i` on writing.
+
+    For historical reasons, it is necessary to accept as valid complex numbers
+    that are surrounded by parenthesis.
+- tag_uri: tag:stsci.edu:asdf/core/constant-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/constant-1.0.0
+  title: Specify that a value is a constant.
+  description: Used as a utility to indicate that value is a literal constant.
+- tag_uri: tag:stsci.edu:asdf/core/extension_metadata-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/extension_metadata-1.0.0
+  title: Metadata about specific ASDF extensions that were used to create this file.
+  description: Metadata about specific ASDF extensions that were used to create this
+    file.
+- tag_uri: tag:stsci.edu:asdf/core/externalarray-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/externalarray-1.0.0
+  title: Point to an array-like object in an external file.
+  description: |-
+    Allow referencing of array-like objects in external files. These files can be
+    any type of file and in any absolute or relative location to the asdf file.
+    Loading of these files into arrays is not handled by asdf.
+- tag_uri: tag:stsci.edu:asdf/core/history_entry-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/history_entry-1.0.0
+  title: An entry in the file history.
+  description: |-
+    A record of an operation that has been performed
+    upon a file.
+- tag_uri: tag:stsci.edu:asdf/core/integer-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/integer-1.0.0
+  title: Arbitrary precision integer value.
+  description: Represents an arbitrarily large integer value.
+- tag_uri: tag:stsci.edu:asdf/core/ndarray-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/ndarray-1.0.0
+  title: An *n*-dimensional array.
+  description: |-
+    There are two ways to store the data in an ndarray.
+
+    - Inline in the tree: This is recommended only for small arrays.  In
+      this case, the entire ``ndarray`` tag may be a nested list, in
+      which case the type of the array is inferred from the content.
+      (See the rules for type inference in the ``inline-data``
+      definition below.)  The inline data may also be given in the
+      ``data`` property, in which case it is possible to explicitly
+      specify the ``datatype`` and other properties.
+
+    - External to the tree: The data comes from a [block](ref:block)
+      within the same ASDF file or an external ASDF file referenced by a
+      URI.
+- tag_uri: tag:stsci.edu:asdf/core/software-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/software-1.0.0
+  title: Describes a software package.
+  description: General-purpose description of a software package.
+- tag_uri: tag:stsci.edu:asdf/core/subclass_metadata-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/subclass_metadata-1.0.0
+  title: Metadata on a serialized subclass of an ASDF-enabled type.
+  description: |-
+    Identifies the specific subclass that was serialized,
+    to enable ASDF readers to correctly deserialize the object.
+- tag_uri: tag:stsci.edu:asdf/core/table-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/table-1.0.0
+  title: A table.
+  description: |-
+    A table is represented as a list of columns, where each entry is a
+    [column](ref:core/column-1.0.0)
+    object, containing the data and some additional information.
+
+    The data itself may be stored inline as text, or in binary in either
+    row- or column-major order by use of the `strides` property on the
+    individual column arrays.
+
+    Each column in the table must have the same first (slowest moving)
+    dimension.
+- tag_uri: tag:stsci.edu:asdf/fits/fits-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/fits/fits-1.0.0
+  title: A FITS file inside of an ASDF file.
+  description: |-
+    This schema is useful for distributing ASDF files that can
+    automatically be converted to FITS files by specifying the exact
+    content of the resulting FITS file.
+
+    Not all kinds of data in FITS are directly representable in ASDF.
+    For example, applying an offset and scale to the data using the
+    `BZERO` and `BSCALE` keywords.  In these cases, it will not be
+    possible to store the data in the native format from FITS and also
+    be accessible in its proper form in the ASDF file.
+
+    Only image and binary table extensions are supported.
+- tag_uri: tag:stsci.edu:asdf/time/time-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/time/time-1.1.0
+  title: Represents an instance in time.
+  description: |-
+    A "time" is a single instant in time.  It may explicitly specify the
+    way time is represented (the "format") and the "scale" which
+    specifies the offset and scaling relation of the unit of time.
+
+    Specific emphasis is placed on supporting time scales (e.g. UTC,
+    TAI, UT1, TDB) and time representations (e.g. JD, MJD, ISO 8601)
+    that are used in astronomy and required to calculate, e.g., sidereal
+    times and barycentric corrections.
+
+    Times may be represented as one of the following:
+
+    - an object, with explicit `value`, and optional `format`, `scale`
+      and `location`.
+
+    - a string, in which case the format is guessed from across
+      the unambiguous options (`iso`, `byear`, `jyear`, `yday`), and the
+      scale is hardcoded to `UTC`.
+
+    In either case, a single time tag may be used to represent an
+    n-dimensional array of times, using either an `ndarray` tag or
+    inline as (possibly nested) YAML lists.  If YAML lists, the same
+    format must be used for all time values.
+
+    The precision of the numeric formats should only be assumed to be as
+    good as an IEEE-754 double precision (float64) value.  If
+    higher-precision is required, the `iso` or `yday` format should be
+    used.
+- tag_uri: tag:stsci.edu:asdf/unit/defunit-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/defunit-1.0.0
+  title: Define a new physical unit.
+  description: |-
+    Defines a new unit.  It can be used to either:
+
+    - Define a new base unit.
+
+    - Create a new unit name that is a equivalent to a given unit.
+
+    The new unit must be defined before any unit tags that use it.
+- tag_uri: tag:stsci.edu:asdf/unit/quantity-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/quantity-1.1.0
+  title: Represents a Quantity object from astropy
+  description: |-
+    A Quantity object represents a value that has some unit
+    associated with the number.
+- tag_uri: tag:stsci.edu:asdf/unit/unit-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
+  title: Physical unit.
+  description: |-
+    This represents a physical unit, in [VOUnit syntax, Version 1.0](http://www.ivoa.net/documents/VOUnits/index.html).
+    Where units are not explicitly tagged, they are assumed to be in VOUnit syntax.

--- a/resources/asdf-format.org/core/schemas/extension_manifest-1.0.0.yaml
+++ b/resources/asdf-format.org/core/schemas/extension_manifest-1.0.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: http://stsci.edu/schemas/yaml-schema/draft-01
-id: asdf://asdf-format.org/core/schemas/extension_manifest-1.0
+id: asdf://asdf-format.org/core/schemas/extension_manifest-1.0.0
 title: ASDF extension manifest
 description: >
   Manifest of additional tags and other features associated

--- a/scripts/generate-core-manifests.py
+++ b/scripts/generate-core-manifests.py
@@ -1,0 +1,63 @@
+# Generate the file in resources/asdf-format.org/core/manifests/
+
+import glob
+import os
+
+import yaml
+
+os.chdir(os.path.join(os.path.dirname(__file__), ".."))
+
+SCHEMA_PATTERNS = [
+    "schemas/stsci.edu/asdf/core/*.yaml",
+    "schemas/stsci.edu/asdf/fits/*.yaml",
+    "schemas/stsci.edu/asdf/time/*.yaml",
+    "schemas/stsci.edu/asdf/unit/*.yaml",
+    "schemas/stsci.edu/asdf/wcs/*.yaml",
+]
+
+
+def represent_string(dumper, data):
+    if len(data.splitlines()) > 1:
+        style = "|"
+    else:
+        style = None
+
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
+
+
+yaml.SafeDumper.add_representer(str, represent_string)
+
+schemas_by_tag = {}
+for pattern in SCHEMA_PATTERNS:
+    for path in glob.glob(pattern):
+        schema = yaml.safe_load(open(path).read())
+        tag = "tag:stsci.edu:" + schema["id"].split("http://stsci.edu/schemas/")[-1]
+        schemas_by_tag[tag] = schema
+
+for path in sorted(glob.glob("schemas/stsci.edu/asdf/version_map-*.yaml")):
+    version_map = yaml.safe_load(open(path).read())
+    version = path.split("/")[-1].split("-")[-1].split(".yaml")[0]
+    tags = sorted([k + "-" + str(v) for k, v in version_map["tags"].items() if "/transform/" not in k])
+
+    tag_defs = []
+    for tag in tags:
+        schema = schemas_by_tag[tag]
+        tag_def = {
+            "tag_uri": tag,
+            "schema_uri": schema["id"],
+            "title": schema["title"].strip(),
+            "description": schema["description"].strip(),
+        }
+        tag_defs.append(tag_def)
+
+    manifest = {
+        "id": f"asdf://asdf-format.org/core/manifests/core-{version}",
+        "extension_uri": f"asdf://asdf-format.org/core/extensions/core-{version}",
+        "title": f"Core extension {version}",
+        "description": "Tags for ASDF core objects.",
+        "asdf_standard_requirement": version,
+        "tags": tag_defs,
+    }
+
+    with open(f"resources/asdf-format.org/core/manifests/core-{version}.yaml", "w") as f:
+        yaml.dump(manifest, f, sort_keys=False, Dumper=yaml.SafeDumper)

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,10 +6,14 @@ from urllib.parse import urljoin
 
 
 ROOT_PATH = Path(__file__).parent.parent
+
 SCHEMAS_PATH = ROOT_PATH / "schemas" / "stsci.edu" / "asdf"
 DOCS_PATH = ROOT_PATH / "docs" / "source"
 DOCS_SCHEMAS_PATH = DOCS_PATH / "schemas"
 YAML_SCHEMA_PATH = ROOT_PATH / "schemas" / "stsci.edu" / "yaml-schema"
+
+RESOURCES_PATH = ROOT_PATH / "resources" / "asdf-format.org"
+MANIFESTS_PATH = RESOURCES_PATH / "core" / "manifests"
 
 VERSION_MAP_PATHS = list(SCHEMAS_PATH.glob("version_map-*.yaml"))
 

--- a/tests/test_asdf_schema.py
+++ b/tests/test_asdf_schema.py
@@ -21,41 +21,18 @@ def test_nested_object_validation(path, create_validator):
     metaschema = load_yaml(path)
     validator = create_validator(metaschema)
 
-    schema = {
-        "$schema": metaschema["id"],
-        "type": "object",
-        "properties": {
-            "foo": {
-                "datatype": "float32",
-            },
-        },
-    }
+    schema = {"$schema": metaschema["id"], "type": "object", "properties": {"foo": {"datatype": "float32"}}}
     # No error here
     validator.validate(schema)
 
-    schema = {
-        "$schema": metaschema["id"],
-        "type": "object",
-        "properties": {
-            "foo": {
-                "datatype": "banana",
-            },
-        },
-    }
+    schema = {"$schema": metaschema["id"], "type": "object", "properties": {"foo": {"datatype": "banana"}}}
     with pytest.raises(ValidationError, match="'banana' is not valid"):
         validator.validate(schema)
 
     schema = {
         "$schema": metaschema["id"],
         "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "foo": {
-                    "ndim": "twelve",
-                },
-            },
-        },
+        "items": {"type": "object", "properties": {"foo": {"ndim": "twelve"}}},
     }
     with pytest.raises(ValidationError):
         validator.validate(schema)

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -1,0 +1,31 @@
+import asdf
+
+import pytest
+
+from common import load_yaml, MANIFESTS_PATH, RESOURCES_PATH
+
+
+MANIFEST_PATHS = sorted(MANIFESTS_PATH.glob("*.yaml"))
+MANIFEST_SCHEMA_PATH = RESOURCES_PATH / "core" / "schemas" / "extension_manifest-1.0.0.yaml"
+MANIFEST_SCHEMA_ID = "asdf://asdf-format.org/core/schemas/extension_manifest-1.0.0"
+
+
+@pytest.mark.parametrize("path", MANIFEST_PATHS)
+def test_manifest(path, tag_to_schema):
+    manifest = load_yaml(path)
+
+    with asdf.config_context() as config:
+        config.add_resource_mapping({MANIFEST_SCHEMA_ID: MANIFEST_SCHEMA_PATH.read_bytes()})
+
+        manifest_schema = asdf.schema.load_schema(MANIFEST_SCHEMA_ID)
+        asdf.schema.validate(manifest, schema=manifest_schema)
+
+    assert "title" in manifest
+    assert "description" in manifest
+
+    for tag in manifest["tags"]:
+        assert tag["tag_uri"] in tag_to_schema
+        schema = tag_to_schema[tag["tag_uri"]][0]
+        assert tag["schema_uri"] == schema["id"]
+        assert "title" in tag
+        assert "description" in tag

--- a/tests/test_yaml_schema.py
+++ b/tests/test_yaml_schema.py
@@ -21,41 +21,18 @@ def test_nested_object_validation(path, create_validator):
     metaschema = load_yaml(path)
     validator = create_validator(metaschema)
 
-    schema = {
-        "$schema": metaschema["id"],
-        "type": "object",
-        "properties": {
-            "foo": {
-                "flowStyle": "block",
-            },
-        },
-    }
+    schema = {"$schema": metaschema["id"], "type": "object", "properties": {"foo": {"flowStyle": "block"}}}
     # No error here
     validator.validate(schema)
 
-    schema = {
-        "$schema": metaschema["id"],
-        "type": "object",
-        "properties": {
-            "foo": {
-                "flowStyle": "funky",
-            },
-        },
-    }
+    schema = {"$schema": metaschema["id"], "type": "object", "properties": {"foo": {"flowStyle": "funky"}}}
     with pytest.raises(ValidationError, match="'funky' is not one of"):
         validator.validate(schema)
 
     schema = {
         "$schema": metaschema["id"],
         "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "foo": {
-                    "propertyOrder": "a,b,c,d",
-                },
-            },
-        },
+        "items": {"type": "object", "properties": {"foo": {"propertyOrder": "a,b,c,d"}}},
     }
     with pytest.raises(ValidationError):
         validator.validate(schema)


### PR DESCRIPTION
This adds manifest files that correspond to each version_map.  They'll be used in asdf-astropy to create extensions that implement support for units and quantities.