### PR TITLE
Add extension_metadata tag to older version maps/manifests

### DIFF
--- a/resources/asdf-format.org/core/manifests/core-1.2.0.yaml
+++ b/resources/asdf-format.org/core/manifests/core-1.2.0.yaml
@@ -45,6 +45,11 @@ tags:
   schema_uri: http://stsci.edu/schemas/asdf/core/constant-1.0.0
   title: Specify that a value is a constant.
   description: Used as a utility to indicate that value is a literal constant.
+- tag_uri: tag:stsci.edu:asdf/core/extension_metadata-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/extension_metadata-1.0.0
+  title: Metadata about specific ASDF extensions that were used to create this file.
+  description: Metadata about specific ASDF extensions that were used to create this
+    file.
 - tag_uri: tag:stsci.edu:asdf/core/history_entry-1.0.0
   schema_uri: http://stsci.edu/schemas/asdf/core/history_entry-1.0.0
   title: An entry in the file history.

--- a/resources/asdf-format.org/core/manifests/core-1.3.0.yaml
+++ b/resources/asdf-format.org/core/manifests/core-1.3.0.yaml
@@ -45,6 +45,11 @@ tags:
   schema_uri: http://stsci.edu/schemas/asdf/core/constant-1.0.0
   title: Specify that a value is a constant.
   description: Used as a utility to indicate that value is a literal constant.
+- tag_uri: tag:stsci.edu:asdf/core/extension_metadata-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/core/extension_metadata-1.0.0
+  title: Metadata about specific ASDF extensions that were used to create this file.
+  description: Metadata about specific ASDF extensions that were used to create this
+    file.
 - tag_uri: tag:stsci.edu:asdf/core/externalarray-1.0.0
   schema_uri: http://stsci.edu/schemas/asdf/core/externalarray-1.0.0
   title: Point to an array-like object in an external file.

--- a/schemas/stsci.edu/asdf/version_map-1.2.0.yaml
+++ b/schemas/stsci.edu/asdf/version_map-1.2.0.yaml
@@ -7,6 +7,7 @@ tags:
   tag:stsci.edu:asdf/core/column: 1.0.0
   tag:stsci.edu:asdf/core/complex: 1.0.0
   tag:stsci.edu:asdf/core/constant: 1.0.0
+  tag:stsci.edu:asdf/core/extension_metadata: 1.0.0
   tag:stsci.edu:asdf/core/history_entry: 1.0.0
   tag:stsci.edu:asdf/core/ndarray: 1.0.0
   tag:stsci.edu:asdf/core/software: 1.0.0

--- a/schemas/stsci.edu/asdf/version_map-1.3.0.yaml
+++ b/schemas/stsci.edu/asdf/version_map-1.3.0.yaml
@@ -7,6 +7,7 @@ tags:
   tag:stsci.edu:asdf/core/column: 1.0.0
   tag:stsci.edu:asdf/core/complex: 1.0.0
   tag:stsci.edu:asdf/core/constant: 1.0.0
+  tag:stsci.edu:asdf/core/extension_metadata: 1.0.0
   tag:stsci.edu:asdf/core/externalarray: 1.0.0
   tag:stsci.edu:asdf/core/history_entry: 1.0.0
   tag:stsci.edu:asdf/core/integer: 1.0.0


### PR DESCRIPTION
The extension_metadata tag was added in ASDF Standard 1.2.0:

https://github.com/asdf-format/asdf-standard/commit/c5313dda7a96d122012d594603518cea2a00194c#diff-314cd1da9cd8c76bcc041e47f574086723c322e98241f94c74e2563eea194cf5

but never actually included in the version_map-1.2.0 or version_map-1.3.0 file.  The manifests were created from the version_maps, so the oversight was propagated to them as well.

