### PR TITLE
Updates to `extension_manifest` to allow for multiple `schema_uri` per `tag`.

### DIFF
--- a/resources/asdf-format.org/core/schemas/extension_manifest-1.0.0.yaml
+++ b/resources/asdf-format.org/core/schemas/extension_manifest-1.0.0.yaml
@@ -85,7 +85,11 @@ properties:
             schema_uri:
               description: >
                 URI of schema used to validate objects with this tag.
-              type: string
+              anyOf:
+                - type: string
+                - type: array
+                  items:
+                    type: string
             title:
               description: >
                 Short description of the tag.


### PR DESCRIPTION
Allowing multiple `schema_uri` per `tag` has been proposed in PR asdf-format/asdf#1058. This PR updates the asdf-standard's schema for `extension_manifest` to reflect this possibility.