### PR TITLE
Add changelog and actions workflows

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,19 @@
+name: Changelog
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, synchronize, reopened]
+
+jobs:
+  changelog:
+    name: Confirm changelog entry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Grep for PR number in CHANGES.rst
+        run: grep -P '\[[^\]]*#${{github.event.number}}[,\]]' CHANGES.rst
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog-entry-needed') }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,16 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    uses: spacetelescope/action-publish_to_pypi/.github/workflows/workflow.yml@master
+    with:
+      test: false
+      build_platform_wheels: false # Set to true if your package contains a C extension
+    secrets:
+      user: ${{ secrets.PYPI_USERNAME_ASDF_MAINTAINER }}
+      password: ${{ secrets.PYPI_PASSWORD_ASDF_MAINTAINER }} # WARNING: Do not hardcode secret values here! If you want to use a different user or password, you can override this secret by creating one with the same name in your Github repository settings.
+      test_password: ${{ secrets.PYPI_PASSWORD_ASDF_MAINTAINER_TEST }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,4 @@
+1.0.0 (unreleased)
+-------------------
+
+- Add installable Python package to replace use of this repo as a submodule.  [#292]


### PR DESCRIPTION
This adds:

- CHANGES.rst file
- actions workflow that enforces new entries in CHANGES.rst (unless the `no-changelog-entry-needed` label is present)
- actions workflow that publishes the package to pypi when a GitHub release record is created