### PR TITLE
Fixed bug in manifest integration tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ docs =
     sphinx-asdf
 test =
     pytest
+    pytest-sugar
     pyyaml
     asdf >= 2.8.0
     astropy
@@ -59,6 +60,7 @@ asdf_schema_xfail_tests =
     stsci.edu/asdf/core/ndarray-1.0.0.yaml::test_example_2
 asdf_schema_tests_enabled = true
 asdf_schema_ignore_unrecognized_tag = true
+addopts = --color=yes
 
 [flake8]
 ignore = E501, E203, W503

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,11 +8,15 @@ import yaml
 def get_resources():
     resources_root = Path(__file__).parent.parent / "resources"
 
-    return list(resources_root.glob("**/*.yaml"))
+    return {str(path.relative_to(resources_root)): path for path in resources_root.glob("**/*.yaml")}
 
 
-@pytest.mark.parametrize("resource_path", get_resources())
-def test_resource(resource_path):
+RESOURCES = get_resources()
+
+
+@pytest.mark.parametrize("resource", RESOURCES)
+def test_resource(resource):
+    resource_path = RESOURCES[resource]
     resource_manager = asdf.get_config().resource_manager
 
     with resource_path.open("rb") as f:
@@ -26,11 +30,16 @@ def test_resource(resource_path):
 
 def get_manifests():
     manifests_root = Path(__file__).parent.parent / "resources" / "manifests" / "asdf-format.org"
-    return list(manifests_root.glob("*.yaml"))
+
+    return {str(path.relative_to(manifests_root)): path for path in manifests_root.glob("**/*.yaml")}
 
 
-@pytest.mark.parametrize("manifest_path", get_manifests())
-def test_manifest(manifest_path):
+MANIFESTS = get_manifests()
+
+
+@pytest.mark.parametrize("manifest", MANIFESTS)
+def test_manifest(manifest):
+    manifest_path = MANIFESTS[manifest]
     resource_manager = asdf.get_config().resource_manager
 
     with manifest_path.open("rb") as f:


### PR DESCRIPTION
Fixes a bug in the manifest integration tests.

It updates the integration tests to follow the convention in asdf-format/asdf-transform-schemas#37, so that tests are parameterized using the schema name rather than an arbitrary variable.