### PR TITLE
Add standard specifier to examples

### DIFF
--- a/resources/schemas/stsci.edu/asdf/time/time-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/asdf/time/time-1.0.0.yaml
@@ -36,21 +36,25 @@ description: |
 examples:
   -
     - Example ISO time
+    - asdf-standard-1.0.0
     - |
         !time/time-1.0.0 "2000-12-31T13:05:27.737"
 
   -
     - Example year, day-of-year and time format time
+    - asdf-standard-1.0.0
     - |
         !time/time-1.0.0 "2001:003:04:05:06.789"
 
   -
     - Example Besselian Epoch time
+    - asdf-standard-1.0.0
     - |
         !time/time-1.0.0 B2000.0
 
   -
     - Example Besselian Epoch time, equivalent to above
+    - asdf-standard-1.0.0
     - |
         !time/time-1.0.0
           value: 2000.0
@@ -58,12 +62,14 @@ examples:
 
   -
     - Example list of times
+    - asdf-standard-1.0.0
     - |
         !time/time-1.0.0
           ["2000-12-31T13:05:27.737", "2000-12-31T13:06:38.444"]
 
   -
     - Example of an array of times
+    - asdf-standard-1.0.0
     - |
         !time/time-1.0.0
           value: !core/ndarray-1.0.0
@@ -73,6 +79,7 @@ examples:
 
   -
     - Example with a location
+    - asdf-standard-1.0.0
     - |
         !time/time-1.0.0
           value: 2000.0


### PR DESCRIPTION
Fixes astropy/asdf-astropy#82

Note this can only be merged once asdf-format/asdf#1143 is merged and released.

This fixes the reported bug by specifying the examples be run under the correct asdf-standard version