### PR TITLE
Add intersphinx link to ASDF library

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,6 +35,8 @@ version = [ver for ver in configuration["classifiers"] if "ASDF Standard Version
 # The full version, including alpha/beta/rc tags
 release = get_distribution(configuration["name"]).version
 
+intersphinx_mapping["asdf"] = ("https://asdf.readthedocs.io/en/latest/", None)  # noqa
+
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,8 @@ ASDF Standard
 This document describes the Advanced Scientific Data Format (ASDF),
 pronounced *AZ*-diff.
 
+The ASDF python implementation documentation can be found :ref:`here <asdf:asdf>`.
+
 .. only:: html
 
     Contents:


### PR DESCRIPTION
During the workshop it was suggested that we add a link from the ASDF library to the ASDF python library