### PR TITLE
Fix schema for compatibility with rad

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ The stable ASDF Standard is v1.5.0
   written from ``asdf-astropy``. [#319]
 - Move packaging to ``pyproject.toml`` file from ``setup.cfg`` and ``setup.py``
   files. [#321]
+- Remove `tag` from within the `time-1.1.0` schema. [#323]
 
 1.0.2 (2022-04-15)
 ------------------

--- a/resources/schemas/stsci.edu/asdf/time/time-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/asdf/time/time-1.1.0.yaml
@@ -2,7 +2,6 @@
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://stsci.edu/schemas/asdf/time/time-1.1.0"
-tag: "tag:stsci.edu:asdf/time/time-1.1.0"
 title: Represents an instance in time.
 description: |
   A "time" is a single instant in time.  It may explicitly specify the

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -21,7 +21,7 @@ def test_manifest(path, tag_to_schema):
     assert "description" in manifest
 
     for tag in manifest["tags"]:
-        if 'time-1.1.0' not in tag['tag_uri']:
+        if "time-1.1.0" not in tag["tag_uri"]:
             assert tag["tag_uri"] in tag_to_schema
             schema = tag_to_schema[tag["tag_uri"]][0]
             assert tag["schema_uri"] == schema["id"]

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -21,8 +21,9 @@ def test_manifest(path, tag_to_schema):
     assert "description" in manifest
 
     for tag in manifest["tags"]:
-        assert tag["tag_uri"] in tag_to_schema
-        schema = tag_to_schema[tag["tag_uri"]][0]
-        assert tag["schema_uri"] == schema["id"]
+        if 'time-1.1.0' not in tag['tag_uri']:
+            assert tag["tag_uri"] in tag_to_schema
+            schema = tag_to_schema[tag["tag_uri"]][0]
+            assert tag["schema_uri"] == schema["id"]
         assert "title" in tag
         assert "description" in tag

--- a/tests/test_version_map.py
+++ b/tests/test_version_map.py
@@ -35,7 +35,8 @@ def test_version_map(path, schema_tags):
 
     for tag_base, tag_version in vm["tags"].items():
         tag = f"{tag_base}-{tag_version}"
-        assert tag in schema_tags, f"{path.name} specifies missing tag {tag}"
+        if "time-1.1.0" not in tag:
+            assert tag in schema_tags, f"{path.name} specifies missing tag {tag}"
 
     assert len(vm["tags"].keys()) == len(set(vm["tags"].keys())), f"{path.name} contains duplicate tags"
 


### PR DESCRIPTION
Changes to the rad schemas, require the dropping of the `tag` entry in the `time-1.1.0` schema. This should not cause any issues as the `tag` in the schema is unnecessary for proper schema functioning, but does prevent the use of the schema to build another tagged object.