### PR TITLE
FIx classifiers in pyproject.toml

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,8 @@ The stable ASDF Standard is v1.5.0
   written from ``asdf-astropy``. [#319]
 - Move packaging to ``pyproject.toml`` file from ``setup.cfg`` and ``setup.py``
   files. [#321]
-- Remove `tag` from within the `time-1.1.0` schema. [#323]
-- Remove `tag` from within the remaining schemas. [#326]
+- Remove ``tag`` from within the ``time-1.1.0`` schema. [#323]
+- Remove ``tag`` from within the remaining schemas. [#326]
 
 1.0.2 (2022-04-15)
 ------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,8 @@ author = f"{configuration['authors'][0]['name']} <{configuration['authors'][0]['
 copyright = f"{datetime.datetime.now().year}, {configuration['authors'][0]}"
 
 # The short X.Y version
-version = [ver for ver in configuration["classifiers"] if "ASDF Standard Version" in ver][0].split(" :: ")[-1]
+with open(Path(__file__).parent.parent.parent / "README.md") as readme:
+    version = readme.readline().split(" ")[-1]
 
 # The full version, including alpha/beta/rc tags
 release = get_distribution(configuration["name"]).version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Development Status :: 5 - Production/Stable',
-    'ASDF Standard Version :: 1.6.0',
 ]
 dependencies = [
     'importlib_resources >= 3; python_version<"3.9"'


### PR DESCRIPTION
Fix bad classifiers in pyproject.toml for pypi.

Fixes error from this action: https://github.com/asdf-format/asdf-standard/runs/7736087140?check_suite_focus=true