### PR TITLE
Add `quantity-1.2.0` to support optional `datatype`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+1.1.0 (unreleased)
+------------------
+
+The in progress ASDF Standard is v1.6.0
+
+The stable ASDF Standard is v1.5.0
+
+- Add new ``quantity-1.2.0`` schema to support ``datatype`` option. [#351]
+
+
 1.0.3 (2022-08-08)
 ------------------
 

--- a/docs/source/schemas/legacy.rst
+++ b/docs/source/schemas/legacy.rst
@@ -10,3 +10,4 @@ The following legacy schemas and not part of the most recent ASDF standard versi
     core/asdf-1.0.0
     time/time-1.0.0
     time/time-1.1.0
+    unit/quantity-1.1.0

--- a/docs/source/schemas/unit.rst
+++ b/docs/source/schemas/unit.rst
@@ -9,4 +9,4 @@ The ``unit`` module contains schema to support the units of physical quantities.
 
    unit/unit-1.0.0
    unit/defunit-1.0.0
-   unit/quantity-1.1.0
+   unit/quantity-1.2.0

--- a/resources/manifests/asdf-format.org/core/core-1.6.0.yaml
+++ b/resources/manifests/asdf-format.org/core/core-1.6.0.yaml
@@ -165,8 +165,8 @@ tags:
     - Create a new unit name that is a equivalent to a given unit.
 
     The new unit must be defined before any unit tags that use it.
-- tag_uri: tag:stsci.edu:asdf/unit/quantity-1.1.0
-  schema_uri: http://stsci.edu/schemas/asdf/unit/quantity-1.1.0
+- tag_uri: tag:stsci.edu:asdf/unit/quantity-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/quantity-1.2.0
   title: Represents a Quantity object from astropy
   description: |-
     A Quantity object represents a value that has some unit

--- a/resources/schemas/stsci.edu/asdf/time/time-1.2.0.yaml
+++ b/resources/schemas/stsci.edu/asdf/time/time-1.2.0.yaml
@@ -85,13 +85,13 @@ examples:
           format: jyear
           scale: tdb
           location:
-            x: !unit/quantity-1.1.0
+            x: !unit/quantity-1.2.0
               value: 6378100
               unit: !unit/unit-1.0.0 m
-            y: !unit/quantity-1.1.0
+            y: !unit/quantity-1.2.0
               value: 0
               unit: !unit/unit-1.0.0 m
-            z: !unit/quantity-1.1.0
+            z: !unit/quantity-1.2.0
               value: 0
               unit: !unit/unit-1.0.0 m
 
@@ -272,11 +272,11 @@ anyOf:
         type: object
         properties:
           x:
-            $ref: "../unit/quantity-1.1.0"
+            $ref: "../unit/quantity-1.2.0"
           y:
-            $ref: "../unit/quantity-1.1.0"
+            $ref: "../unit/quantity-1.2.0"
           z:
-            $ref: "../unit/quantity-1.1.0"
+            $ref: "../unit/quantity-1.2.0"
         required: [x, y, z]
 
     required: [value]

--- a/resources/schemas/stsci.edu/asdf/unit/quantity-1.2.0.yaml
+++ b/resources/schemas/stsci.edu/asdf/unit/quantity-1.2.0.yaml
@@ -18,6 +18,14 @@ examples:
           value: 3.14159
           unit: km
 
+    - A quantity consisting of a scalar value with datatype and unit
+    - asdf-standard-1.6.0
+    - |
+        !unit/quantity-1.2.0
+          value: 3.14159
+          unit: km
+          datatype: float32
+
   -
     - A quantity consisting of a single value in an array
     - asdf-standard-1.6.0

--- a/resources/schemas/stsci.edu/asdf/unit/quantity-1.2.0.yaml
+++ b/resources/schemas/stsci.edu/asdf/unit/quantity-1.2.0.yaml
@@ -1,0 +1,66 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+title: >
+  Represents a Quantity object from astropy
+description: |
+  A Quantity object represents a value that has some unit
+  associated with the number.
+
+examples:
+  -
+    - A quantity consisting of a scalar value and unit
+    - asdf-standard-1.6.0
+    - |
+        !unit/quantity-1.2.0
+          value: 3.14159
+          unit: km
+
+  -
+    - A quantity consisting of a single value in an array
+    - asdf-standard-1.6.0
+    - |
+        !unit/quantity-1.2.0
+          value: !core/ndarray-1.0.0 [2.71828]
+          unit: A
+
+  -
+    - A quantity with an array of values
+    - asdf-standard-1.6.0
+    - |
+        !unit/quantity-1.2.0
+          value: !core/ndarray-1.0.0 [1, 2, 3, 4]
+          unit: s
+
+  -
+    - A quantity with an n-dimensional array of values
+    - asdf-standard-1.6.0
+    - |
+        !unit/quantity-1.2.0
+          value: !core/ndarray-1.0.0
+            datatype: float64
+            data: [[1, 2, 3],
+                   [4, 5, 6]]
+          unit: pc
+
+
+type: object
+properties:
+  value:
+    description: |
+      A vector of one or more values
+    anyOf:
+      - type: number
+      - $ref: "../core/ndarray-1.0.0"
+  unit:
+    description: |
+      The unit corresponding to the values
+    $ref: unit-1.0.0
+  datatype:
+    description: |
+      The datatype for scalar quantities
+    $ref: "../core/ndarray-1.0.0#definitions/scalar-datatype"
+required: [value, unit]
+...

--- a/resources/schemas/stsci.edu/asdf/version_map-1.6.0.yaml
+++ b/resources/schemas/stsci.edu/asdf/version_map-1.6.0.yaml
@@ -18,6 +18,6 @@ tags:
   tag:stsci.edu:asdf/fits/fits: 1.0.0
   tag:stsci.edu:asdf/time/time: 1.2.0
   tag:stsci.edu:asdf/unit/defunit: 1.0.0
-  tag:stsci.edu:asdf/unit/quantity: 1.1.0
+  tag:stsci.edu:asdf/unit/quantity: 1.2.0
   tag:stsci.edu:asdf/unit/unit: 1.0.0
 ...


### PR DESCRIPTION
In astropy/asdf-astropy#131 in order to fix round-tripping of `dtype` of `astropy.units.Quantity` objects, the converter now writes out a `datatype` field for scalar quantities. This PR explicitly adds this to the `quantity` schema, which necessitates a new schema/tag, `quantity-1.2.0`.