### PR TITLE
update tox.ini for tox 4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
 deps=
     twine
 commands=
-    twine check {distdir}/*
+    twine check {work_dir}/{package_env}/dist/*
 
 [testenv:black]
 deps =


### PR DESCRIPTION
ignore the bad branch name, this is not pinning to <4

instead it's updating the no longer available dist_dir to something that worked locally

this PR is to test for other issues