### PR TITLE
Fix URI fragment format in metaschema references

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ The stable ASDF Standard is v1.5.0
 - Add new ``ndarray-1.1.0`` schema to fix #345 [#350]
 - Remove ``unit-1.1.0`` erroneously added in #350 [#355]
 - Refactor file layout [#360]
+- Fix URI fragment format in metaschema references. [#373]
 
 1.0.3 (2022-08-08)
 ------------------

--- a/src/asdf_standard/resources/schemas/stsci.edu/asdf/asdf-schema-1.0.0.yaml
+++ b/src/asdf_standard/resources/schemas/stsci.edu/asdf/asdf-schema-1.0.0.yaml
@@ -75,7 +75,7 @@ allOf:
         additionalProperties:
           anyOf:
             - $ref: "#"
-            - $ref: "http://json-schema.org/draft-04/schema#definitions/stringArray"
+            - $ref: "http://json-schema.org/draft-04/schema#/definitions/stringArray"
       allOf:
         $ref: "#/definitions/schemaArray"
       anyOf:

--- a/src/asdf_standard/resources/schemas/stsci.edu/yaml-schema/draft-01.yaml
+++ b/src/asdf_standard/resources/schemas/stsci.edu/yaml-schema/draft-01.yaml
@@ -137,7 +137,7 @@ allOf:
         additionalProperties:
           anyOf:
             - $ref: "#"
-            - $ref: "http://json-schema.org/draft-04/schema#definitions/stringArray"
+            - $ref: "http://json-schema.org/draft-04/schema#/definitions/stringArray"
       allOf:
         $ref: "#/definitions/schemaArray"
       anyOf:


### PR DESCRIPTION
A URI fragment without a leading `/` has no meaning in draft 4 (in later drafts it becomes an "anchor" which is a named label in the target schema).  We were getting away with this but the upcoming jsonschema release is going to be more strict.