### PR TITLE
add jsonschema as test dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ test = [
     'astropy >= 5.0.4',
     'gwcs',
     'packaging>=16.0',
+    'jsonschema<4.18',
 ]
 
 [project.urls]


### PR DESCRIPTION
jsonschema is used directly in a test fixture but is not listed as a test dependency

https://github.com/asdf-format/asdf-standard/blob/47d1b8683e4865f9178736d70dfefe0d7506358a/src/asdf_standard/tests/conftest.py#L171-L185