### PR TITLE
add float16 support to version 1.6.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ The stable ASDF Standard is v1.5.0
 - Fix URI fragment format in metaschema references. [#373]
 - Fix URI fragment format in quantity-1.2 schema [#374]
 - Drop support for python 3.8 [#390]
+- Add ``float16`` to ``ndarray-1.1.0`` [#411]
 
 1.0.3 (2022-08-08)
 ------------------

--- a/resources/schemas/stsci.edu/asdf/core/ndarray-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/asdf/core/ndarray-1.1.0.yaml
@@ -170,6 +170,9 @@ definitions:
       - `uint8`, `uint16`, `uint32`, `uint64`: Unsigned integer types,
         with the given bit size.
 
+      - `float16 `: Half-precision floating-point type or "binary16",
+        as defined in IEEE 754.
+
       - `float32`: Single-precision floating-point type or "binary32",
         as defined in IEEE 754.
 
@@ -198,7 +201,7 @@ definitions:
     anyOf:
       - type: string
         enum: [int8, uint8, int16, uint16, int32, uint32, int64, uint64,
-               float32, float64, complex64, complex128, bool8]
+               float16, float32, float64, complex64, complex128, bool8]
       - type: array
         items:
           - type: string


### PR DESCRIPTION
This partially addresses https://github.com/asdf-format/asdf-standard/issues/410 by adding `float16` support (which is natively supported by numpy) to asdf-standard version 1.6.0.