### PR TITLE
add resources symlink

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+# Exclude the symlink included to allow
+# importlib.resources to work for editable installs
+exclude src/*/resources

--- a/src/asdf_standard/integration.py
+++ b/src/asdf_standard/integration.py
@@ -1,5 +1,4 @@
 import sys
-from pathlib import Path
 
 if sys.version_info < (3, 9):
     import importlib_resources
@@ -10,13 +9,7 @@ import asdf_standard
 
 
 def get_resource_mappings():
-    resources_root = importlib_resources.files(asdf_standard) / "resources"
-    if not resources_root.is_dir():
-        # In an editable install, the resources directory will exist off the
-        # repository root:
-        resources_root = Path(__file__).absolute().parent.parent.parent / "resources"
-        if not resources_root.is_dir():
-            raise RuntimeError("Missing resources directory")
+    resources_root = importlib_resources.files("asdf_standard") / "resources"
 
     return [
         asdf_standard.DirectoryResourceMapping(

--- a/src/asdf_standard/resources
+++ b/src/asdf_standard/resources
@@ -1,0 +1,1 @@
+../../resources


### PR DESCRIPTION
This PR adds a symlink ink `src/asdf-standard` to the `resources` directory (and excludes this `symlink` from packaging). This allows editable installs of `asdf-standard` to use `importlib.resources` to inspect `resources`.

This is the first PR in a 3 part series to hopefully break the link between `asdf-standard` and `asdf` which prevents `asdf-standard` from adding a new standard without breaking `asdf` tests. The general plan is:
- this PR
- update `asdf` to use `importlib.resources` to inspect `asdf-standard` to determine what versions are available: https://github.com/asdf-format/asdf/pull/1702
- add a new standard version `1.7.0-dev` to show the above worked: https://github.com/asdf-format/asdf-standard/pull/415