### PR TITLE
remove astropy and gwcs test deps

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,17 +7,12 @@
 
 import datetime
 import importlib.metadata
-import sys
 from pathlib import Path
 
 import tomli
+from sphinx_asdf.conf import *  # noqa: F403
 
 # -- Project information -----------------------------------------------------
-try:
-    from sphinx_astropy.conf.v1 import *  # noqa: F403, F401
-except ImportError:
-    print("ERROR: the documentation requires the sphinx-astropy package to be installed")
-    sys.exit(1)
 
 # Get configuration information from `pyproject.toml`
 with open(Path(__file__).parent.parent.parent / "pyproject.toml", "rb") as configuration_file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,6 @@ test = [
     'pytest',
     'pyyaml',
     'asdf >= 2.8.0',
-    'astropy >= 5.0.4',
-    'gwcs',
     'packaging>=16.0',
     'jsonschema<4.18',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ docs = [
     'tomli',
     'sphinx >= 4.0',
     'sphinx-asdf >= 0.1.3',
-    'sphinx-astropy',
     'graphviz',
     'matplotlib',
     'docutils',


### PR DESCRIPTION
This PR removes seemingly unnecessary test and docs dependencies.

- test:
  - astropy
  - gwcs
- docs:
  - sphinx-astropy