### PR TITLE
Remove the last `tag` in the schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ The stable ASDF Standard is v1.5.0
 - Fix URI fragment format in quantity-1.2 schema [#374]
 - Drop support for python 3.8 [#390]
 - Add ``float16`` to ``ndarray-1.1.0`` [#411]
+- Remove unneeded ``tag`` keyword from ``fits`` schema [#421]
 
 1.0.3 (2022-08-08)
 ------------------

--- a/resources/schemas/stsci.edu/asdf/fits/fits-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/asdf/fits/fits-1.0.0.yaml
@@ -72,7 +72,6 @@ examples:
               - [EXTNAME, ERR, extension name]
               - [BUNIT, DN, Units of the error array]
 
-tag: "tag:stsci.edu:asdf/fits/fits-1.0.0"
 type: array
 items:
   description: >

--- a/resources/schemas/stsci.edu/asdf/fits/fits-1.1.0.yaml
+++ b/resources/schemas/stsci.edu/asdf/fits/fits-1.1.0.yaml
@@ -73,7 +73,6 @@ examples:
               - [EXTNAME, ERR, extension name]
               - [BUNIT, DN, Units of the error array]
 
-tag: "tag:stsci.edu:asdf/fits/fits-1.1.0"
 type: array
 items:
   description: >

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,16 +116,6 @@ def docs_manifest_ids():
     return result
 
 
-def _get_tag(schema):
-    if "tag" in schema:
-        return schema["tag"]
-    elif "anyOf" in schema:
-        for elem in schema["anyOf"]:
-            if "tag" in elem:
-                return elem["tag"]
-    return None
-
-
 @pytest.fixture(scope="session")
 def id_to_schema(schemas):
     result = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,16 +127,6 @@ def _get_tag(schema):
 
 
 @pytest.fixture(scope="session")
-def latest_schema_tags(latest_schemas):
-    result = set()
-    for schema in latest_schemas:
-        tag = _get_tag(schema)
-        if tag is not None:
-            result.add(tag)
-    return result
-
-
-@pytest.fixture(scope="session")
 def schema_tags(schemas):
     result = set()
     for schema in schemas:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,18 +127,6 @@ def _get_tag(schema):
 
 
 @pytest.fixture(scope="session")
-def tag_to_schema(schemas):
-    result = {}
-    for schema in schemas:
-        tag = _get_tag(schema)
-        if tag is not None:
-            if tag not in result:
-                result[tag] = []
-            result[tag].append(schema)
-    return result
-
-
-@pytest.fixture(scope="session")
 def id_to_schema(schemas):
     result = {}
     for schema in schemas:
@@ -150,7 +138,7 @@ def id_to_schema(schemas):
 
 
 @pytest.fixture(scope="session")
-def assert_schema_correct(tag_to_schema, id_to_schema):
+def assert_schema_correct(id_to_schema):
     def _assert_schema_correct(path):
         __tracebackhide__ = True
 
@@ -179,9 +167,6 @@ def assert_schema_correct(tag_to_schema, id_to_schema):
         assert len(schema["description"].strip()) > 0, f"{path.name} description must have content"
 
         assert len(id_to_schema[schema["id"]]) == 1, f"{path.name} does not have a unique id"
-
-        if "tag" in schema:
-            assert len(tag_to_schema[schema["tag"]]) == 1, f"{path.name} does not have a unique tag"
 
         id_base, _ = split_id(schema["id"])
         for example_id in list_example_ids(schema):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,16 +127,6 @@ def _get_tag(schema):
 
 
 @pytest.fixture(scope="session")
-def schema_tags(schemas):
-    result = set()
-    for schema in schemas:
-        tag = _get_tag(schema)
-        if tag is not None:
-            result.add(tag)
-    return result
-
-
-@pytest.fixture(scope="session")
 def tag_to_schema(schemas):
     result = {}
     for schema in schemas:

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -8,7 +8,7 @@ MANIFEST_SCHEMA_ID = "asdf://asdf-format.org/core/schemas/extension_manifest-1.0
 
 
 @pytest.mark.parametrize("path", MANIFEST_PATHS)
-def test_manifest(path, tag_to_schema):
+def test_manifest(path):
     manifest = load_yaml(path)
 
     with asdf.config_context() as config:

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -21,14 +21,5 @@ def test_manifest(path, tag_to_schema):
     assert "description" in manifest
 
     for tag in manifest["tags"]:
-        if (
-            "time" not in tag["tag_uri"]
-            and "core" not in tag["tag_uri"]
-            and "unit" not in tag["tag_uri"]
-            and "wcs" not in tag["tag_uri"]
-        ):
-            assert tag["tag_uri"] in tag_to_schema
-            schema = tag_to_schema[tag["tag_uri"]][0]
-            assert tag["schema_uri"] == schema["id"]
         assert "title" in tag
         assert "description" in tag

--- a/tests/test_version_map.py
+++ b/tests/test_version_map.py
@@ -21,7 +21,7 @@ LATEST_PATH = SORTED_PATHS[-1]
 
 
 @pytest.mark.parametrize("path", VERSION_MAP_PATHS)
-def test_version_map(path, schema_tags):
+def test_version_map(path):
     assert VALID_FILENAME_RE.match(path.name) is not None, f"{path.name} is an invalid version map filename"
 
     assert_yaml_header_and_footer(path)

--- a/tests/test_version_map.py
+++ b/tests/test_version_map.py
@@ -42,42 +42,6 @@ def test_version_map(path, schema_tags):
         assert False, message
 
 
-def test_latest_version_map(latest_schema_tags):
-    """
-    The current latest version map has some special requirements.
-    """
-    vm = load_yaml(LATEST_PATH)
-
-    tag_base_to_version = dict([tag.rsplit("-", 1) for tag in latest_schema_tags])
-
-    expected_tag_bases = {t for t in tag_base_to_version.keys() if not is_deprecated(t)}
-    vm_tag_bases = set(vm["tags"].keys())
-    if not expected_tag_bases.issubset(vm_tag_bases):
-        missing_tag_bases = expected_tag_bases - vm_tag_bases
-        insert_list = "\n".join(
-            sorted(f"""{tag_base}-{tag_base_to_version[tag_base]}""" for tag_base in missing_tag_bases)
-        )
-        message = (
-            f"{LATEST_PATH.name} must include the latest version of "
-            "every non-deprecated schema with a tag.  Update the deprecation "
-            "list in tests/common.py, or add the following missing schemas: \n"
-            f"{insert_list}"
-        )
-        assert False, message
-
-    incorrect_tag_bases = sorted(tag for tag in expected_tag_bases if vm["tags"][tag] != tag_base_to_version[tag])
-    if len(incorrect_tag_bases) > 0:
-        update_list = "\n".join(
-            [f"""{tag}: {vm["tags"][tag]} --> {tag_base_to_version[tag]}""" for tag in incorrect_tag_bases]
-        )
-        message = (
-            f"{LATEST_PATH.name} must include the latest version of "
-            "every non-deprecated schema with a tag.  Update the following: \n"
-            f"{update_list}"
-        )
-        assert False, message
-
-
 @pytest.mark.parametrize("path, previous_path", zip(SORTED_PATHS[1:], SORTED_PATHS[0:-1]))
 def test_version_map_tags_retained(path, previous_path):
     """

--- a/tests/test_version_map.py
+++ b/tests/test_version_map.py
@@ -33,11 +33,6 @@ def test_version_map(path, schema_tags):
     assert vm["FILE_FORMAT"] in VALID_FILE_FORMAT_VERSIONS
     assert vm["YAML_VERSION"] in VALID_YAML_VERSIONS
 
-    for tag_base, tag_version in vm["tags"].items():
-        tag = f"{tag_base}-{tag_version}"
-        if "time" not in tag and "core" not in tag and "unit" not in tag and "wcs" not in tag:
-            assert tag in schema_tags, f"{path.name} specifies missing tag {tag}"
-
     assert len(vm["tags"].keys()) == len(set(vm["tags"].keys())), f"{path.name} contains duplicate tags"
 
     sorted_tags = sorted(list(vm["tags"].keys()))


### PR DESCRIPTION
This PR removes the `tag` in the `fits` schemas. As this was the last tag, several tests are now testing nothing and are removed in this PR.

jwst regression tests:
https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FJWST-Developers-Pull-Requests/detail/JWST-Developers-Pull-Requests/1191/tests

show 1 error from an unclosed fine in the `test_against_standard[pool_004_wfs]` which occurs randomly and rather frequently.

The asdf downstream test is due to asdf specifically looking for `tag` in the `fits` schema to check that the schema was registered and is addressed in: https://github.com/asdf-format/asdf/pull/1749