### PR TITLE
remove uses of jsonschema in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,8 @@ docs = [
 test = [
     'pytest',
     'pyyaml',
-    'asdf >= 2.8.0',
+    'asdf >= 3.0.0',
     'packaging>=16.0',
-    'jsonschema<4.18',
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,6 @@ from common import (
     ref_to_id,
     split_id,
 )
-from jsonschema.validators import Draft4Validator, RefResolver
 
 
 @pytest.fixture(scope="session")
@@ -205,20 +204,3 @@ def assert_latest_schema_correct(latest_schema_ids):
                 )
 
     return _assert_latest_schema_correct
-
-
-@pytest.fixture(scope="session")
-def create_validator(schemas, yaml_schemas):
-    """
-    Fixture method that creates validators with access to schemas in
-    this repository.
-    """
-
-    def _create_validator(schema):
-        store = {s["id"]: s for s in schemas + yaml_schemas}
-
-        resolver = RefResolver.from_schema(schema, id_of=Draft4Validator.ID_OF, store=store)
-
-        return Draft4Validator(schema, resolver=resolver)
-
-    return _create_validator

--- a/tests/test_asdf_schema.py
+++ b/tests/test_asdf_schema.py
@@ -1,6 +1,7 @@
+import asdf
 import pytest
+from asdf.exceptions import ValidationError
 from common import SCHEMAS_PATH, assert_yaml_header_and_footer, load_yaml
-from jsonschema import ValidationError
 
 
 @pytest.mark.parametrize("path", SCHEMAS_PATH.glob("asdf-schema-*.yaml"))
@@ -12,12 +13,12 @@ def test_asdf_schema(path):
 
 
 @pytest.mark.parametrize("path", SCHEMAS_PATH.glob("asdf-schema-*.yaml"))
-def test_nested_object_validation(path, create_validator):
+def test_nested_object_validation(path):
     """
     Test that the validations are applied to nested objects.
     """
     metaschema = load_yaml(path)
-    validator = create_validator(metaschema)
+    validator = asdf.schema.get_validator(schema=metaschema)
 
     schema = {"$schema": metaschema["id"], "type": "object", "properties": {"foo": {"datatype": "float32"}}}
     # No error here

--- a/tests/test_yaml_schema.py
+++ b/tests/test_yaml_schema.py
@@ -1,6 +1,7 @@
+import asdf
 import pytest
+from asdf.exceptions import ValidationError
 from common import YAML_SCHEMA_PATH, assert_yaml_header_and_footer, list_schema_paths, load_yaml
-from jsonschema import ValidationError
 
 
 @pytest.mark.parametrize("path", list_schema_paths(YAML_SCHEMA_PATH))
@@ -12,12 +13,12 @@ def test_yaml_schema(path):
 
 
 @pytest.mark.parametrize("path", YAML_SCHEMA_PATH.glob("*.yaml"))
-def test_nested_object_validation(path, create_validator):
+def test_nested_object_validation(path):
     """
     Test that the validations are applied to nested objects.
     """
     metaschema = load_yaml(path)
-    validator = create_validator(metaschema)
+    validator = asdf.schema.get_validator(schema=metaschema)
 
     schema = {"$schema": metaschema["id"], "type": "object", "properties": {"foo": {"flowStyle": "block"}}}
     # No error here


### PR DESCRIPTION
`jsonschema` was used directly for one fixture `create_validator`. This was replaced with calls to `asdf.schema.get_validator`.

Fixes: #424 