### PR TITLE
update changelog for 1.1.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,9 @@
-1.1.0 (unreleased)
+1.1.1 (unreleased)
+------------------
+
+-
+
+1.1.0 (2024-03-05)
 ------------------
 
 The in progress ASDF Standard is v1.6.0


### PR DESCRIPTION
Regtests:
jwst: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1264/
romancal: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/626/

This PR does not yet mark 1.6.0 as "stable". I think the safest bet is to first make an asdf PR that makes it stable in asdf main. When all issues have been sorted, make another asdf-standard release with 1.6.0 stable (so we have a window to make changes) perhaps increasing the version to 1.6.0. Then make an asdf release (so the pypi version has 1.6.0 as stable).