### PR TITLE
don't build extra docs formats

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ build:
   apt_packages:
     - graphviz
   tools:
-    python: "3.9"
+    python: "3.11"
 
 sphinx:
   configuration: docs/source/conf.py
@@ -17,4 +17,5 @@ python:
       extra_requirements:
         - docs
 
-formats: all
+# No extra formats
+formats: []


### PR DESCRIPTION
docs for 1.1.0 failed to build:
https://asdf-standard.readthedocs.io/en/1.1.0/
due to errors during extra formats:
https://readthedocs.org/projects/asdf-standard/builds/23658134/
which are untested during PR builds:
https://readthedocs.org/projects/asdf-standard/builds/23653286/

This PR disables the extra formats.

Readthedocs will now fail the entire build if the pdf fails (which explains the docs 404):
https://readthedocs.org/projects/asdf-standard/builds/19779263/
and will only build the html format for PRs:
https://docs.readthedocs.io/en/stable/config-file/v2.html#formats

It looks like the docs are also failing on main:
https://readthedocs.org/projects/asdf-standard/builds/23659192/
(I'm not sure where to see this outside of readthedocs)
and has been for at least a year:
https://readthedocs.org/projects/asdf-standard/builds/19482766/
