### PR TITLE
remove statement discouraging anchors and aliases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ------------------
 
 - Update reference files [#409]
+- Remove statement discouraging use of YAML anchors and aliases [#443]
 
 1.1.1 (2024-03-06)
 ------------------

--- a/docs/source/tree.rst
+++ b/docs/source/tree.rst
@@ -213,10 +213,7 @@ allowed.
 .. note::
     The YAML 1.1 standard itself also provides a method for internal
     references called "anchors" and "aliases".  It does not, however,
-    support external references.  While ASDF does not explicitly
-    disallow YAML anchors and aliases, since it explicitly supports
-    all of YAML 1.1, their use is discouraged in favor of the more
-    flexible JSON Pointer/JSON Reference standard described above.
+    support external references.
 
 .. _numeric-literals:
 


### PR DESCRIPTION
As was brought up in https://github.com/asdf-format/asdf/issues/1840
the standard currently discourages anchors and aliases. This PR removes the statement discouraging their use.