### PR TITLE
add python 3.13 testing, fixes to avoid setuptools warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         - linux: py310
         - linux: py311
         - linux: py312
+        - linux: py313
 
   test:
     needs: [core]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,15 +50,14 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "src/asdf_standard/_version.py"
 
-[tool.setuptools]
-packages = ["asdf_standard", "asdf_standard.resources"]
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [tool.setuptools.package-data]
-"asdf_standard.resources" = ["resources/**/*.yaml"]
-
-[tool.setuptools.package-dir]
-"" = "src"
-"asdf_standard.resources" = "resources"
+"asdf_standard.resources" = [
+    "manifests/**/*.yaml",
+    "schemas/**/*.yaml",
+]
 
 [tool.pytest.ini_options]
 asdf_schema_root = 'resources/schemas'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,11 @@ name = 'asdf_standard'
 description = 'The ASDF Standard schemas'
 readme = 'README.md'
 requires-python = '>=3.9'
-license = { file = 'LICENSE' }
+license-files = ['LICENSE']
 authors = [{ name = 'The ASDF Developers', email = 'help@stsci.edu' }]
 classifiers = [
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.11',
     'Development Status :: 5 - Production/Stable',
 ]
 dependencies = [
@@ -44,7 +41,7 @@ test = [
 
 [build-system]
 requires = [
-    "setuptools >=61",
+    "setuptools >=77",
     "setuptools_scm[toml] >=3.4",
     "wheel",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, py312
+envlist = py39, py310, py311, py312, py313
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Closes #458

Updates `pyproject.toml` to avoid:
- a warning due to `license.files` deprecation (in favor of `license-files`)
- a warning due to package discovery (see below)

```
  !!

          ********************************************************************************
          ############################
          # Package would be ignored #
          ############################
          Python recognizes 'asdf_standard.resources.manifests' as an importable package[^1],
          but it is absent from setuptools' `packages` configuration.

          This leads to an ambiguous overall configuration. If you want to distribute this
          package, please make sure that 'asdf_standard.resources.manifests' is explicitly added
          to the `packages` configuration field.

          Alternatively, you can also rely on setuptools' discovery methods
          (for example by using `find_namespace_packages(...)`/`find_namespace:`
          instead of `find_packages(...)`/`find:`).

          You can read more about "package discovery" on setuptools documentation page:

          - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

          If you don't want 'asdf_standard.resources.manifests' to be distributed and are
          already explicitly excluding 'asdf_standard.resources.manifests' via
          `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
          you can try to use `exclude_package_data`, or `include-package-data=False` in
          combination with a more fine grained `package-data` configuration.

          You can read more about "package data files" on setuptools documentation page:

          - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


          [^1]: For Python, any directory (with suitable naming) can be imported,
                even if it does not contain any `.py` files.
                On the other hand, currently there is no concept of package data
                directory, all directories are treated like packages.
          ********************************************************************************
```

With the changes in this PR no warnings are seen when running `pip install -v .` with setuptools 79.