### PR TITLE
add sunpy times to time 1.3.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+1.3.0 (unreleased)
+------------------
+
+- Add utime and tai_seconds formats to new time-1.3.0 [#461]
+
 1.2.0 (2025-05-21)
 ------------------
 

--- a/resources/manifests/asdf-format.org/astronomy/astronomy-1.1.0.yaml
+++ b/resources/manifests/asdf-format.org/astronomy/astronomy-1.1.0.yaml
@@ -1,0 +1,96 @@
+id: asdf://asdf-format.org/astronomy/manifests/astronomy-1.0.0
+extension_uri: asdf://asdf-format.org/astronomy/extensions/astronomy-1.0.0
+title: ASDF astronomy extension 1.0.0
+description: Astronomy related (non-core) ASDF objects
+asdf_standard_requirement:
+  gte: 1.6.0
+tags:
+- tag_uri: tag:stsci.edu:asdf/table/column-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/table/column-1.1.0
+  title: A column in a table.
+  description: |-
+    Each column contains a name and an array of data, and an optional description
+    and unit.
+- tag_uri: tag:stsci.edu:asdf/unit/defunit-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/defunit-1.0.0
+  title: Define a new physical unit.
+  description: |-
+    Defines a new unit.  It can be used to either:
+
+    - Define a new base unit.
+
+    - Create a new unit name that is a equivalent to a given unit.
+
+    The new unit must be defined before any unit tags that use it.
+- tag_uri: tag:stsci.edu:asdf/fits/fits-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/fits/fits-1.1.0
+  title: A FITS file inside of an ASDF file.
+  description: |-
+    This schema is useful for distributing ASDF files that can
+    automatically be converted to FITS files by specifying the exact
+    content of the resulting FITS file.
+
+    Not all kinds of data in FITS are directly representable in ASDF.
+    For example, applying an offset and scale to the data using the
+    `BZERO` and `BSCALE` keywords.  In these cases, it will not be
+    possible to store the data in the native format from FITS and also
+    be accessible in its proper form in the ASDF file.
+
+    Only image and binary table extensions are supported.
+- tag_uri: tag:stsci.edu:asdf/unit/quantity-1.2.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/quantity-1.2.0
+  title: Represents a Quantity object from astropy
+  description: |-
+    A Quantity object represents a value that has some unit
+    associated with the number.
+- tag_uri: tag:stsci.edu:asdf/table/table-1.1.0
+  schema_uri: http://stsci.edu/schemas/asdf/table/table-1.1.0
+  title: A table.
+  description: |-
+    A table is represented as a list of columns, where each entry is a
+    [column](ref:table/column-1.1.0)
+    object, containing the data and some additional information.
+
+    The data itself may be stored inline as text, or in binary in either
+    row- or column-major order by use of the `strides` property on the
+    individual column arrays.
+
+    Each column in the table must have the same first (slowest moving)
+    dimension.
+- tag_uri: tag:stsci.edu:asdf/time/time-1.3.0
+  schema_uri: http://stsci.edu/schemas/asdf/time/time-1.3.0
+  title: Represents an instance in time.
+  description: |-
+    A "time" is a single instant in time.  It may explicitly specify the
+    way time is represented (the "format") and the "scale" which
+    specifies the offset and scaling relation of the unit of time.
+
+    Specific emphasis is placed on supporting time scales (e.g. UTC,
+    TAI, UT1, TDB) and time representations (e.g. JD, MJD, ISO 8601)
+    that are used in astronomy and required to calculate, e.g., sidereal
+    times and barycentric corrections.
+
+    Times may be represented as one of the following:
+
+    - an object, with explicit `value`, and optional `format`, `scale`
+      and `location`.
+
+    - a string, in which case the format is guessed from across
+      the unambiguous options (`iso`, `byear`, `jyear`, `yday`), and the
+      scale is hardcoded to `UTC`.
+
+    In either case, a single time tag may be used to represent an
+    n-dimensional array of times, using either an `ndarray` tag or
+    inline as (possibly nested) YAML lists.  If YAML lists, the same
+    format must be used for all time values.
+
+    The precision of the numeric formats should only be assumed to be as
+    good as an IEEE-754 double precision (float64) value.  If
+    higher-precision is required, the `iso` or `yday` format should be
+    used.
+- tag_uri: tag:stsci.edu:asdf/unit/unit-1.0.0
+  schema_uri: http://stsci.edu/schemas/asdf/unit/unit-1.0.0
+  title: Physical unit.
+  description: |-
+    This represents a physical unit, in [VOUnit syntax, Version 1.0](http://www.ivoa.net/documents/VOUnits/index.html).
+    Where units are not explicitly tagged, they are assumed to be in VOUnit syntax.

--- a/resources/manifests/asdf-format.org/astronomy/astronomy-1.1.0.yaml
+++ b/resources/manifests/asdf-format.org/astronomy/astronomy-1.1.0.yaml
@@ -1,6 +1,6 @@
-id: asdf://asdf-format.org/astronomy/manifests/astronomy-1.0.0
-extension_uri: asdf://asdf-format.org/astronomy/extensions/astronomy-1.0.0
-title: ASDF astronomy extension 1.0.0
+id: asdf://asdf-format.org/astronomy/manifests/astronomy-1.1.0
+extension_uri: asdf://asdf-format.org/astronomy/extensions/astronomy-1.1.0
+title: ASDF astronomy extension
 description: Astronomy related (non-core) ASDF objects
 asdf_standard_requirement:
   gte: 1.6.0

--- a/resources/schemas/stsci.edu/asdf/time/time-1.3.0.yaml
+++ b/resources/schemas/stsci.edu/asdf/time/time-1.3.0.yaml
@@ -1,0 +1,305 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/time/time-1.3.0"
+title: Represents an instance in time.
+description: |
+  A "time" is a single instant in time.  It may explicitly specify the
+  way time is represented (the "format") and the "scale" which
+  specifies the offset and scaling relation of the unit of time.
+
+  Specific emphasis is placed on supporting time scales (e.g. UTC,
+  TAI, UT1, TDB) and time representations (e.g. JD, MJD, ISO 8601)
+  that are used in astronomy and required to calculate, e.g., sidereal
+  times and barycentric corrections.
+
+  Times may be represented as one of the following:
+
+  - an object, with explicit `value`, and optional `format`, `scale`
+    and `location`.
+
+  - a string, in which case the format is guessed from across
+    the unambiguous options (`iso`, `byear`, `jyear`, `yday`), and the
+    scale is hardcoded to `UTC`.
+
+  In either case, a single time tag may be used to represent an
+  n-dimensional array of times, using either an `ndarray` tag or
+  inline as (possibly nested) YAML lists.  If YAML lists, the same
+  format must be used for all time values.
+
+  The precision of the numeric formats should only be assumed to be as
+  good as an IEEE-754 double precision (float64) value.  If
+  higher-precision is required, the `iso` or `yday` format should be
+  used.
+
+examples:
+  -
+    - Example ISO time
+    - asdf-standard-1.6.0
+    - |
+        !time/time-1.3.0 "2000-12-31T13:05:27.737"
+
+  -
+    - Example year, day-of-year and time format time
+    - asdf-standard-1.6.0
+    - |
+        !time/time-1.3.0 "2001:003:04:05:06.789"
+
+  -
+    - Example Besselian Epoch time
+    - asdf-standard-1.6.0
+    - |
+        !time/time-1.3.0 B2000.0
+
+  -
+    - Example Besselian Epoch time, equivalent to above
+    - asdf-standard-1.6.0
+    - |
+        !time/time-1.3.0
+          value: 2000.0
+          format: byear
+
+  -
+    - Example list of times
+    - asdf-standard-1.6.0
+    - |
+        !time/time-1.3.0
+          ["2000-12-31T13:05:27.737", "2000-12-31T13:06:38.444"]
+
+  -
+    - Example of an array of times
+    - asdf-standard-1.6.0
+    - |
+        !time/time-1.3.0
+          value: !core/ndarray-1.1.0
+            data: [2000, 2001]
+            datatype: float64
+          format: jyear
+
+  -
+    - Example with a location
+    - asdf-standard-1.6.0
+    - |
+        !time/time-1.3.0
+          value: 2000.0
+          format: jyear
+          scale: tdb
+          location:
+            x: !unit/quantity-1.2.0
+              value: 6378100
+              unit: !unit/unit-1.0.0 m
+            y: !unit/quantity-1.2.0
+              value: 0
+              unit: !unit/unit-1.0.0 m
+            z: !unit/quantity-1.2.0
+              value: 0
+              unit: !unit/unit-1.0.0 m
+
+definitions:
+  iso_time:
+    type: string
+    pattern: "[0-9]{4}-(0[1-9])|(1[0-2])-(0[1-9])|([1-2][0-9])|(3[0-1])[T ]([0-1][0-9])|(2[0-4]):[0-5][0-9]:[0-5][0-9](.[0-9]+)?"
+
+  byear:
+    type: string
+    pattern: "B[0-9]+(.[0-9]+)?"
+
+  jyear:
+    type: string
+    pattern: "J[0-9]+(.[0-9]+)?"
+
+  yday:
+    type: string
+    pattern: "[0-9]{4}:(00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3[0-5][0-9])|(36[0-5]):([0-1][0-9])|([0-1][0-9])|(2[0-4]):[0-5][0-9]:[0-5][0-9](.[0-9]+)?"
+
+  string_formats:
+    anyOf:
+      - $ref: "#/definitions/iso_time"
+      - $ref: "#/definitions/byear"
+      - $ref: "#/definitions/jyear"
+      - $ref: "#/definitions/yday"
+
+  array_of_strings:
+    type: array
+    items:
+      anyOf:
+        - $ref: "#/definitions/array_of_strings"
+        - $ref: "#/definitions/string_formats"
+
+  format:
+    description: |
+      The format of the time.
+
+      The supported formats are:
+
+      - `iso`: ISO 8601 compliant date-time format
+        `YYYY-MM-DDTHH:MM:SS.sss...`.  For example,
+        `2000-01-01 00:00:00.000` is midnight on January 1,
+        2000.  The `T` separating the date from the time
+        section is optional.
+
+      - `yday`: Year, day-of-year and time as
+        `YYYY:DOY:HH:MM:SS.sss...`. The day-of-year (DOY) goes
+        from 001 to 365 (366 in leap years). For example,
+        `2000:001:00:00:00.000` is midnight on January 1,
+        2000.
+
+      - `byear`: Besselian Epoch year, eg. `B1950.0`.  The `B`
+        is optional if the `byear` format is explicitly
+        specified.
+
+      - `jyear`: Julian Epoch year, eg. `J2000.0`.  The `J` is
+        optional if the `jyear` format is explicitly
+        specified.
+
+      - `decimalyear`: Time as a decimal year, with integer
+        values corresponding to midnight of the first day of
+        each year. For example 2000.5 corresponds to the ISO
+        time `2000-07-02 00:00:00`.
+
+      - `jd`: Julian Date time format. This represents the
+        number of days since the beginning of the Julian
+        Period. For example, 2451544.5 in `jd` is midnight on
+        January 1, 2000.
+
+      - `mjd`: Modified Julian Date time format. This
+        represents the number of days since midnight on
+        November 17, 1858. For example, 51544.0 in MJD is
+        midnight on January 1, 2000.
+
+      - `gps`: GPS time: seconds from 1980-01-06 00:00:00 UTC
+        For example, 630720013.0 is midnight on January 1,
+        2000.
+
+      - `unix`: Unix time: seconds from 1970-01-01 00:00:00
+        UTC. For example, 946684800.0 in Unix time is midnight
+        on January 1, 2000.  [TODO: Astropy's definition of
+        UNIX time doesn't match POSIX's here.  What should we
+        do for the purposes of ASDF?]
+
+      - `utime`: UT seconds from 1979-01-01 00:00:00 UTC, ignoring leap seconds.
+
+      - `tai_seconds`: SI seconds from 1958-01-01 00:00:00, which includes UTC leap seconds.
+
+    enum:
+      - byear
+      - cxcsec
+      - decimalyear
+      - gps
+      - iso
+      - jd
+      - jyear
+      - mjd
+      - unix
+      - unix_tai
+      - yday
+      - utime
+      - tai_seconds
+
+  other_format:
+    description: |
+      The other formats supported by astropy.time:
+      https://docs.astropy.org/en/latest/time/index.html#time-format
+
+    enum:
+      - byear_str
+      - datetime
+      - fits
+      - isot
+      - jyear_str
+      - plot_date
+      - ymdhms
+      - datetime64
+
+anyOf:
+  - $ref: "#/definitions/string_formats"
+
+  - $ref: "#/definitions/array_of_strings"
+
+  - type: object
+    properties:
+      value:
+        description: |
+          The value(s) of the time.
+
+        anyOf:
+          - $ref: "#/definitions/string_formats"
+          - $ref: "#/definitions/array_of_strings"
+          - $ref: "../core/ndarray-1.1.0"
+          - type: number
+
+      format:
+        description: |
+          The format used to save the time in ASDF
+
+          If not provided, the the format should be guessed from the
+          string from among the following unambiguous options:
+          `iso`, `byear`, `jyear` and `yday`.
+
+        $ref: "#/definitions/format"
+
+      base_format:
+        description: |
+          The original format of the time object
+
+        oneOf:
+          - $ref: "#/definitions/format"
+          - $ref: "#/definitions/other_format"
+
+      scale:
+        description: |
+          The time scale (or time standard) is a specification for
+          measuring time: either the rate at which time passes; or
+          points in time; or both. See also [3] and [4].
+
+          These scales are defined in detail in [SOFA Time Scale and
+          Calendar Tools](http://www.iausofa.org/sofa_ts_c.pdf).
+
+          The supported time scales are:
+
+          - `utc`: Coordinated Universal Time (UTC).  This is the
+            default time scale, except for `gps`, `unix`.
+
+          - `tai`: International Atomic Time (TAI).
+
+          - `tcb`: Barycentric Coordinate Time (TCB).
+
+          - `tcg`: Geocentric Coordinate Time (TCG).
+
+          - `tdb`: Barycentric Dynamical Time (TDB).
+
+          - `tt`: Terrestrial Time (TT).
+
+          - `ut1`: Universal Time (UT1).
+
+        enum:
+          - utc
+          - tai
+          - tcb
+          - tcg
+          - tdb
+          - tt
+          - ut1
+
+      location:
+        description: |
+          Specifies the observer location for scales that are
+          sensitive to observer location, currently only `tdb`.  May
+          be specified either with geocentric coordinates (X, Y, Z)
+          with an optional unit or geodetic coordinates:
+            - `long`: longitude in degrees
+            - `lat`: in degrees
+            - `h`: optional height
+
+        type: object
+        properties:
+          x:
+            $ref: "../unit/quantity-1.2.0"
+          y:
+            $ref: "../unit/quantity-1.2.0"
+          z:
+            $ref: "../unit/quantity-1.2.0"
+        required: [x, y, z]
+
+    required: [value]
+...


### PR DESCRIPTION
This PR adds the `utime` and `tai_seconds` formats to the time schema. This triggered:
- a bump to time-1.3.0
- a bump in the astronomy manifest to 1.1.0

Once this is merged support for the new manifest will be added to asdf-astropy:
https://github.com/astropy/asdf-astropy/pull/282

and some tests added to sunpy to confirm the time formats round-trip:
https://github.com/sunpy/sunpy/pull/8234

To provide some context, these formats previously worked due to a bug in the ndarray schema which effectively disabled the time schema (it validated anything):
https://github.com/asdf-format/asdf-standard/issues/345
when this bug was fixed it broke the custom `utime` and `tai_seconds` formats that sunpy adds to astropy Time objects (since neither format is listed as supported in the time schema).