### PR TITLE
use new terminology to disambiguate "standard"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+1.4.0 (unreleased)
+------------------
+
+- Update documentation to use new terminology. The
+  ASDF specification refers to the description of the file
+  format whereas the ASDF core schemas refers to the versioned
+  collection of schemas for core objects (ndarray, software, etc) [#473]
+
 1.3.0 (2025-06-11)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-ASDF standard 1.6.0
-===================
+ASDF specification and core schemas
+===================================
 ![CI](https://github.com/asdf-format/asdf-standard/actions/workflows/ci.yml/badge.svg)
 ![Downstream](https://github.com/asdf-format/asdf-standard/actions/workflows/downstream.yml/badge.svg)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)

--- a/docs/source/file_layout.rst
+++ b/docs/source/file_layout.rst
@@ -172,7 +172,7 @@ Each block begins with the following header:
   size of the remainder of the header (not including the length of the
   ``header_size`` entry itself or the ``block_magic_token``), in bytes.
   It is stored explicitly in the header itself so that the header may be
-  enlarged in a future version of the ASDF standard while retaining
+  enlarged in a future version of the ASDF specification while retaining
   backward compatibility.  Importantly, ASDF parsers should not assume
   a fixed size of the header, but should obey the ``header_size``
   defined in the file.  In ASDF version 0.1, this should be at least
@@ -227,7 +227,7 @@ The following bit flags are understood in the ``flags`` field:
 Compression
 ^^^^^^^^^^^
 
-Currently, two block compression types are defined in the standard
+Currently, two block compression types are defined in the specification
 and all implementations should strive to support these:
 
 - ``zlib``: The zlib lossless compression algorithm.  It is widely
@@ -239,7 +239,7 @@ and all implementations should strive to support these:
   released under a permissive license in the `bzip2 library
   <http://www.bzip.org/>`__.
 
-The standard does not currently specify how additional 4-byte compression
+The specification does not currently specify how additional 4-byte compression
 type identifiers should be agreed upon. It is currently up to
 implementations to define how other identifiers are mapped to compression
 algorithms.
@@ -371,7 +371,7 @@ multiple files, but it does not require any additions to the file
 format itself.  There is nothing indicating that an ASDF file is in
 exploded form, other than the fact that some or all of its blocks come
 from external files.  The exact way in which a file is exploded is up
-to the library and tools implementing the standard.  In the simplest
+to the library and tools implementing the specification.  In the simplest
 scenario, to explode a file, each :ref:`ndarray source property
 <core/ndarray-1.2.0>` in the tree is converted from a local block reference
 into a relative URI.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,11 +1,11 @@
 .. _asdf-standard:
 
-ASDF Standard
-=============
+ASDF Specification and core schemas
+===================================
 
-This document describes the `Advanced Scientific Data Format <https://www.asdf-format.org/en/latest/overview.html>`__ (ASDF) Standard.
+This document describes the `Advanced Scientific Data Format <https://www.asdf-format.org/en/latest/overview.html>`__ (ASDF) specification and documents the core schemas.
 
-The ASDF Standard prescribes the specification and implementation standards for creating, editing and reading ASDF files.
+The ASDF specification prescribes the file-format and implementation requirements for creating, editing and reading ASDF files.
 
 Documentation for the `asdf` python implementation can be found at the :ref:`asdf repository <asdf:asdf>`.
 

--- a/docs/source/known_limits.rst
+++ b/docs/source/known_limits.rst
@@ -26,7 +26,7 @@ within the ``int64`` range.  In other words, number must be no greater than
 9,223,372,036,854,775,807 or no less than -9,223,372,036,854,775,806.
 
 
-As of version **1.3.0** of the standard, arbitrary precision integers are
+As of version **1.3.0** of the core schemas, arbitrary precision integers are
 supported using :ref:`integer <core/integer-1.1.0>`.  Like all tags, use of
 this type requires library support.
 

--- a/docs/source/schemas.rst
+++ b/docs/source/schemas.rst
@@ -6,8 +6,7 @@ ASDF Schemas
 ASDF uses `JSON Schema`_ to perform validation of ASDF files. Schema validation
 of ASDF files serves the following purposes:
 
-* Ensures conformity with core data types defined by the ASDF Standard. ASDF
-  readers can detect whether an ASDF file has been modified in a way that would
+* ASDF readers can detect whether an ASDF file has been modified in a way that would
   render it unreadable or unrecognizable.
 * Enables interoperability between ASDF implementations. Implementations that
   recognize the same schema definitions should be able to interpret files
@@ -19,12 +18,12 @@ of ASDF files serves the following purposes:
 
 All ASDF implementations must implement the types defined by the `core schemas
 <core-schema>` and validate against them when reading files. [#]_ The ASDF
-Standard also defines other schemas, which are optional for ASDF implementations
-and maintained as part of the standard (mainly for historical reasons):
+specification also defines other schemas, which are optional for ASDF implementations
+and maintained as part of the specification (mainly for historical reasons):
 
 * :ref:`astronomy <astronomy-schema>`
 
-The ASDF Standard also defines two metaschemas which are used to validate the
+The ASDF specification also defines two metaschemas which are used to validate the
 ASDF schemas themselves:
 
 * :ref:`yaml-schema`
@@ -54,8 +53,8 @@ $schema
 
 ASDF schemas use the top-level ``$schema`` attribute to declare the metaschema
 that is used to validate the schema itself. Most custom ASDF schemas will
-conform to :ref:`YAML Schema <yaml-schema>` defined by the ASDF Standard, and
-so will have the following top-level attribute::
+conform to :ref:`YAML Schema <yaml-schema>` and so will have the following
+top-level attribute::
 
    $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 
@@ -84,7 +83,7 @@ conventions to ensure global uniqueness.
 
 While the ``id`` must be a valid URI, it does not have to describe a real
 location on disk or on a network. For example, the ``id`` values for all
-schemas in the ASDF Standard begin with the prefix
+schemas in the ASDF core schemas begin with the prefix
 ``http://stsci.edu/schemas/asdf/``.  However, as of this writing, none of the
 schemas are actually hosted at that location.
 
@@ -145,14 +144,14 @@ All schema ids should encode the following information:
 * **version**: The version of the schema. See `versioning-conventions` for more
   details.
 
-Consider the schemas from the ASDF Standard as an example. In this case, the
+Consider ASDF core schemas as an example. In this case, the
 **organization** is ``stsci.edu``, which is the web address of the organization
 that created the schemas. The **standard** is ``asdf``. Each individual schema
-in the ASDF Standard has a different **name** field. In the case of the
+in the core schemas has a different **name** field. In the case of the
 :ref:`ndarray <core/ndarray-1.1.0>` data type, for example, the name is
 ``core/ndarray``. The version of `ndarray <core/ndarray-1.1.0>` is ``1.1.0``.
-Some other types in the ASDF Standard have multiple versions, such as
-``quantity-1.1.0`` and :ref:`quantity-1.2.0 <unit/quantity-1.2.0>`.
+Some types in the core schemas have multiple versions, such as
+``ndarray-1.0.0`` and :ref:`ndarray-1.1.0 <core/ndarray-1.1.0>`.
 
 While schema ids can be any valid URI, under this convention they always begin
 with ``http://``. The general format of the id attribute becomes::
@@ -212,7 +211,7 @@ Therefore, in our schema file, we have the following defining the ``id`` of the 
 
 
 Since our schema is just a basic ASDF schema, we will declare that it conforms
-to `yaml-schema` defined by the ASDF Standard::
+to `yaml-schema` defined by the ASDF specification::
 
    $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 
@@ -261,7 +260,7 @@ description::
 We'll also define an optional element for the exposure time unit.
 This is a somewhat contrived example to demonstrate how to include
 elements in your schema that are based on the custom types defined in
-the ASDF standard::
+the ASDF core schemas::
 
     exposure_time_units:
       allOf:
@@ -329,7 +328,7 @@ Extending an existing schema
 `JSON Schema`_ does not support the concept of inheritance, which makes it
 somewhat awkward to express type hierarchies. However, it is possible to create
 a custom schema that adds attributes to an existing schema (e.g. one defined in
-the ASDF Standard). It is important to remember that it is not possible to
+the ASDF core schemas). It is important to remember that it is not possible to
 override or remove any of the attributes from the existing schema.
 
 The following important caveats apply when extending an existing schema:
@@ -343,7 +342,7 @@ The following important caveats apply when extending an existing schema:
   there is no concept of polymorphism).
 
 Here's an example of extending a schema using the `software <core/software-1.0.0>`
-schema defined by the ASDF Standard.  Here's the original schema, for reference::
+schema defined in the ASDF core schemas.  Here's the original schema, for reference::
 
   %YAML 1.1
   ---
@@ -422,7 +421,7 @@ Default annotation
 .. warning::
 
    It is recommended that ``default`` is no longer used  in new schema.
-   As noted below newer versions of the standard will ignore these values.
+   As noted below newer versions of the ASDF specification will ignore these values.
 
 
 The JSON Schema spec includes a schema annotation attribute called ``default`` that
@@ -433,7 +432,7 @@ are available due to references and combiners.  This presents a problem when
 trying to fill in missing data in a file based on the schema ``default``: if
 multiple conflicting values are available, the software does not know how to choose.
 
-Previous versions of the ASDF Standard did not offer guidance on how
+Previous versions of the ASDF specification did not offer guidance on how
 to use ``default``.  The Python reference implementation read the first default
 that it encountered as a literal value and inserted that value into the tree when
 the corresponding attribute was otherwise missing.  Until version 2.8, it also
@@ -442,14 +441,14 @@ resulting files would appear to the casual viewer to be missing data, and may in
 fact be invalid against their schemas if the any of the removed attributes were required.
 
 Implementations **must not** remove attributes with default values from the tree.
-Beginning with ASDF Standard 1.6.0, implementations also must not fill default values
+Beginning with ASDF specification 1.6.0, implementations also must not fill default values
 directly from the schema.  This will avoid ambiguity when multiple schema defaults
 are present, and also permit the ``default`` attribute to contain a description
 that is not appropriate to use as a literal default value.  For example::
 
     default: An array of zeros matching the dimensions of the data array.
 
-For ASDF Standard < 1.6.0, filling default values from the schema is required.  This is
+For ASDF specification < 1.6.0, filling default values from the schema is required.  This is
 necessary to support files written by older versions of the Python implementation.
 
 .. rubric:: Footnotes

--- a/docs/source/schemas/astronomy.rst
+++ b/docs/source/schemas/astronomy.rst
@@ -3,8 +3,8 @@
 Astronomy
 =========
 
-The ASDF standard contains a few astronomy-specific tags that
-are optional but maintained as part of the standard (for historical
+The ASDF specification contains a few astronomy-specific tags that
+are optional but maintained as part of the specification (for historical
 reasons). These include:
 
 .. asdf-autoschemas::

--- a/docs/source/schemas/index.rst
+++ b/docs/source/schemas/index.rst
@@ -1,14 +1,14 @@
 .. _resources:
 
-ASDF Standard Resources
-=======================
+ASDF Specification Resources
+============================
 
-The included schema and manifest resources made available by the ASDF-standard are described below.
+The included schema and manifest resources made available by the ASDF are described below.
 
 .. _schema:
 
-ASDF Standard Schema Definitions
---------------------------------
+ASDF Specification Schema Definitions
+-------------------------------------
 
 ASDF schemas are arranged into "modules".  All ASDF implementations
 must support the "core" module, but the other modules are optional.
@@ -20,7 +20,7 @@ must support the "core" module, but the other modules are optional.
    astronomy.rst
    legacy.rst
 
-The ASDF Standard also defines two meta-schemas that are used for validating
+The ASDF Specification also defines two meta-schemas that are used for validating
 the ASDF schemas themselves. These schemas are useful references when creating
 custom schemas (see `extending-asdf`).
 

--- a/docs/source/schemas/legacy.rst
+++ b/docs/source/schemas/legacy.rst
@@ -3,7 +3,7 @@
 Legacy schemas
 ==============
 
-The following legacy schemas are not part of the most recent ASDF standard version:
+The following legacy schemas are not part of the most recent ASDF core schemas:
 
 .. asdf-autoschemas::
 

--- a/docs/source/schemas/manifest.rst
+++ b/docs/source/schemas/manifest.rst
@@ -1,9 +1,9 @@
 
-ASDF Standard Manifests
------------------------
+ASDF Core Schema Manifests
+--------------------------
 
-The ASDF tags (described by schemas) available under each ASDF standard version are all described
-by a single manifest document for that ASDF standard version.
+The ASDF tags (described by schemas) available under each ASDF core schemas version are all described
+by a single manifest document for that ASDF specification version.
 
 .. asdf-autoschemas::
    :schema_root: ../../resources/manifests

--- a/docs/source/tree.rst
+++ b/docs/source/tree.rst
@@ -10,14 +10,14 @@ numbers, booleans, etc.).  All of this comes "for free" by using `YAML
 <http://yaml.org/spec/1.1/>`__.
 
 Since these core data structures on their own are so flexible, the
-ASDF standard includes a number of schema that define the structure of
+ASDF core schemas includes a number of schema that define the structure of
 higher-level content.  For instance, there is a schema that defines
 how :ref:`n-dimensional array data <core/ndarray-1.1.0>` should be
 described.  These schema are written in a language called
 :ref:`yaml-schema` which is just a thin extension of `JSON Schema,
 Draft 4 <https://json-schema.org/draft-04/schema>`__.  `asdf-schemas` contains an overview of
 how schemas are defined and used by ASDF. :ref:`schema` describes in detail
-all of the schemas provided by the ASDF Standard.
+all of the schemas provided by the ASDF core schemas.
 
 .. _yaml_subset:
 
@@ -83,10 +83,10 @@ For example::
        byteorder: little
      ...
 
-All tags defined in the ASDF standard itself begin with the prefix
+All tags defined in the ASDF core schemas itself begin with the prefix
 ``tag:stsci.edu:asdf/``.  This can be broken down as:
 
-- ``tag:`` The standard prefix used for all YAML tags.
+- ``tag:`` The prefix used for all YAML tags.
 
 - ``stsci.edu`` The owner of the tag.
 
@@ -113,8 +113,8 @@ will be replaced with the prefix ``tag:stsci.edu:asdf/``::
         byteorder: little
 
 An ASDF parser may use the tag to look up the corresponding schema in
-the ASDF standard and validate the element.  The schema definitions
-ship as part of the ASDF standard.
+and validate the element.  The schema definitions
+ship as part of the ASDF core schemas or extensions.
 
 An ASDF parser may also use the tag information to convert the element
 to a native data type.  For example, in Python, an ASDF parser may
@@ -122,7 +122,7 @@ convert a :ref:`ndarray <core/ndarray-1.1.0>` tag to a `Numpy
 <http://www.numpy.org>`__ array instance, providing a convenient and familiar
 interface to the user to access *n*-dimensional data.
 
-The ASDF standard does not require parser implementations to validate
+The ASDF specification does not require parser implementations to validate
 or perform native type conversion, however.  A parser may simply leave
 the tree represented in the low-level basic data structures.  When
 writing an ASDF file, however, the elements in the tree must be
@@ -132,7 +132,7 @@ ASDF parsers must not fail when encountering an unknown tag, but must
 simply retain the low-level data structure and the presence of the
 tag.  This is important, as end users will likely want to store their
 own custom tags in ASDF files alongside the tags defined in the ASDF
-standard itself, and the file must still be readable by ASDF parsers
+core schemas, and the file must still be readable by ASDF parsers
 that do not understand those tags.
 
 .. _references:
@@ -290,11 +290,11 @@ YAML permits serialization of null values using the ``null`` literal::
 
     some_key: null
 
-Previous versions of the ASDF Standard were vague as to how nulls should
+Previous versions of the ASDF specification were vague as to how nulls should
 be handled, and the Python reference implementation did not distinguish
 between keys with null values and keys that were missing altogether (and
 in fact, removed any keys assigned ``None`` from the tree on read or
-write).  Beginning with ASDF Standard 1.6.0, ASDF implementations
+write).  Beginning with ASDF specification 1.6.0, ASDF implementations
 are required to preserve keys even if assigned null values.  This
 requirement does not extend back into previous versions, and users
 of the Python implementation should be advised that the YAML portion

--- a/docs/source/versioning.rst
+++ b/docs/source/versioning.rst
@@ -8,13 +8,11 @@ possible.  This involves being able to add features as needed while
 still allowing older libraries that may not understand those new
 features to reasonably make sense of the rest of the file.
 
-The ASDF standard includes four categories of versions, all of which
-may advance independently of one another.
+ASDF makes extensive use of versioning to retain backwards compatibility
+and as a result many version numbers will be encountered for even
+just a single ASDF file.
 
-- **Standard version**: The version of the standard as a whole.  This
-  version provides a convenient handle to refer to a particular
-  snapshot of the ASDF standard at a given time.  This allows
-  libraries to advertise support for "ASDF standard version X.Y.Z".
+An ASDF file may have several versions:
 
 - **File format version**: Refers to the version of the blocking
   scheme and other details of the low-level file layout.  This is the
@@ -22,31 +20,61 @@ may advance independently of one another.
   every ASDF file and is essential to correctly interpreting the
   various parts of an ASDF file.
 
-- **Schema versions**: Each schema for a particular YAML tag is
-  individually versioned.  This allows schemas to evolve, while still
-  allowing data written to an older version of the schema to be
+- **Standard version**: The version of the standard/specification as a whole.
+  This version provides a convenient handle to refer to a particular
+  snapshot of the ASDF specification at a given time.  This allows
+  libraries to advertise support for "ASDF specification version X.Y.Z".
+
+- **Tag versions**: Rich data structures are "tagged" (a concept inherited
+  from YAML). These tags are versioned to allow ASDF to read and
+  validate old file even if newer versions of the tag (which may
+  link to a new schema) are available.
+
+- **Schema versions**: Each schema (that may correspond to a YAML tag)
+  is individually versioned.  This allows schemas to evolve, while still
+  allowing data written with an older version of the schema to be
   validated correctly.
+
+- **Extension versions**: Schemas and tags added to ASDF via extensions
+  are versioned to aid in backwards compatibility.
 
 - **Package versions**: Schemas might be provided via a package
   distribution system (such as pypi in Python). The version of a
   package that provides schemas might not match the versions of the
   schemas in the package.
 
-.. note::
+Consider the following ASDF file:
 
-   An example of the varied versions one might encounter can be
-   seen when examining the ``asdf-standard`` Python package which
-   provides schemas describing the ASDF standard for python. At the
-   time of writing this note, the ``asdf-standard`` Python package is
-   at version 1.1.1 and provides schemas describing ASDF standards
-   versions 1.0.0 through 1.6.0 all for file format version 1.0.0.
-   The schemas provided have various versions including ndarray-1.0.0
-   and ndarray-1.1.0. These many versions are crucial for ASDF
-   to retain backwards compatibility with older files.
+.. code-block:: yaml
 
-Schemas provided by third parties (i.e. not in the ASDF
-specification itself) are also strongly encouraged to be versioned
-as well.
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.6.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+     name: asdf, version: 4.1.0}
+   history:
+     extensions:
+     - !core/extension_metadata-1.0.0
+       extension_class: asdf.extension._manifest.ManifestExtension
+       extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+       manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.1.1}
+       software: !core/software-1.0.0 {name: asdf, version: 4.1.0}
+   data: !core/ndarray-1.1.0
+     data: [0, 1, 2, 3, 4, 5, 6, 7]
+     datatype: int64
+     shape: [8]
+   ...
+
+In the above example we find:
+
+* File format version 1.0.0
+* Specification/standard version 1.6.0
+* a ``data`` key tagged with ``ndarray`` tag version 1.1.0
+* an extension ``core-1.6.0`` that was used while writing this file
+* a package ``asdf_standard`` versioned 1.1.1 which provided the ``core-1.6.0`` extension manifest
+* a package ``asdf`` versioned 4.1.0 which implemented the support for the ``core-1.6.0`` extension
 
 Version numbers all follow the same convention according to the
 `Semantic Versioning 2.0.0 <http://semver.org/spec/v2.0.0.html>`__
@@ -73,45 +101,23 @@ specification.
   For example, the pre-release of version ``1.2.3`` would be
   ``1.2.3-dev+a2c4``.
 
-Relationship of version numbers
--------------------------------
-
-The major number in the **standard version** is incremented whenever
-the major number in the **file format version** is incremented.
-
-**Schema versions** are created and adjusted independently of the **standard
-version** and the **file format version**. New schemas are created with version
-``1.0.0`` and are updated according to the Semantic Versioning conventions
-discussed above.
-
-An update to any of the **schema versions** will be reflected in a bump of the
-**standard version** as well, although the version numbers will not necessarily
-match. Bumping a particular **schema version** will also require new versions
-of any of the schemas that make reference to it.
-
-For example, schema ``Foo`` has version ``1.0.0`` in version ``1.2.0`` of the
-Standard. We make a backwards compatible change to ``Foo`` and bump its version
-to ``1.1.0``. Schema ``Bar`` contains a  reference to ``Foo``. The current
-version of ``Bar`` is ``1.1.0``, and we must now bump it to ``1.2.0`` to
-reflect the new reference to ``Foo-1.1.0``. We also bump the Standard version
-to ``1.3.0`` to reflect the changes to these schemas.
-
 Handling version mismatches
 ---------------------------
 
-Given these conventions, the ASDF standard recommends certain behavior
-of ASDF libraries.  ASDF libraries should, but are not required, to
+Given the variety of versions it is important to consider how an
+ASDF implenentation will handle version mismatches.
+ASDF implementations should, but are not required, to
 support as many existing versions of the file format and schemas as
 possible, and use the version numbers in the file to act accordingly.
 
 If while reading a file an unknown version number is encountered
-the library should warn the user and return a structure that
+the library should warn the user and must return a structure that
 preserves the version information but does not deserialize the
 versioned object.
 
 For example if the ``foo-1.1.0`` tag is known and
 a file contains a ``foo-1.0.0`` tag the unknown ``1.0.0`` version
-should not be handled like a ``foo-1.1.0`` object. The same
+must not be handled like a ``foo-1.1.0`` object. The same
 is true if the file contains a newer but still unknown version
 (for example ``foo-2.0.0``). This behavior applies to tags
 that differ by any element (major, minor or patch) of the version
@@ -123,8 +129,8 @@ of the following modes of operation:
 - Upgrade the file to the latest versions of the file format and
   schemas understood by the library.
 
-- Preserve the version of the ASDF standard used by the input file.
+- Preserve the version of the ASDF specification used by the input file.
 
 Writing out a file that mixes versions of schema from different
-versions of the ASDF standard is not recommended, though such a file
+versions of the ASDF core schemas is not recommended, though such a file
 should be accepted by readers given the rules above.


### PR DESCRIPTION
This PR updates the documentation to use new terminology for referring to the various things that were previously referred to as a "standard". These include:
- the ASDF standard: referring to the document that describes the file format and how files should be handled
- the ASDF standard: referring to the versioned collections of core schemas (ndarray, etc)
- the asdf standard: the package/repository which includes the above

For someone familiar with the "FITS standard" the use of the term "ASDF standard" is misleading as none of the above describe a commonly agreed upon collection of metadata (a key feature of the "FITS standard"). To try and avoid this confusion going forward I propose that we use (and this PR starts the adoption process):
- the ASDF specification to refer to the document that describes the file format and how files should be handled
- the ASDF core schemas to refer to the versioned collections of core schemas (ndarray, etc)

For the last item (this package and repository) we may want to consider renaming it but that issue is not addressed in this PR.

See https://github.com/asdf-format/asdf-standard/wiki/The-revenge-of-2.0.0-Roadmap#terminology for more details