### PR TITLE
use new pytest-asdf-plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ asdf_schema_skip_tests = """
 asdf_schema_tests_enabled = 'true'
 asdf_schema_ignore_unrecognized_tag = 'true'
 addopts = '--color=yes'
+filterwarnings = [
+    "error",
+]
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ docs = [
 ]
 test = [
     'pytest',
+    'pytest-asdf-plugin',
     'pyyaml',
     'asdf >= 3.0.0',
     'packaging>=16.0',

--- a/src/asdf_standard/resource.py
+++ b/src/asdf_standard/resource.py
@@ -13,7 +13,7 @@ class DirectoryResourceMapping(Mapping):
 
     Parameters
     ----------
-    root : str or importlib.abc.Traversable
+    root : str or importlib.resources.abc.Traversable
         Root directory (or directory-like Traversable) of the resource
         files.  ``str`` will be interpreted as a filesystem path.
     uri_prefix : str

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -3,10 +3,10 @@ import sys
 from collections.abc import Mapping
 from pathlib import Path
 
-if sys.version_info < (3, 9):
-    import importlib_resources as importlib
+if sys.version_info < (3, 11):
+    from importlib.abc import Traversable
 else:
-    import importlib
+    from importlib.resources.abc import Traversable
 
 from asdf_standard import DirectoryResourceMapping
 
@@ -80,7 +80,7 @@ def test_directory_resource_mapping_with_traversable():
     methods outside of the Traversable interface.
     """
 
-    class MockTraversable(importlib.resources.abc.Traversable):
+    class MockTraversable(Traversable):
         def __init__(self, name, value):
             self._name = name
             self._value = value

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -80,7 +80,7 @@ def test_directory_resource_mapping_with_traversable():
     methods outside of the Traversable interface.
     """
 
-    class MockTraversable(importlib.abc.Traversable):
+    class MockTraversable(importlib.resources.abc.Traversable):
         def __init__(self, name, value):
             self._name = name
             self._value = value


### PR DESCRIPTION
This PR switches the pytest plugin to the newly released external version.

The latest scheduled run has 409 passing tests:
https://github.com/asdf-format/asdf-standard/actions/runs/17032869517/job/48278975929#step:10:101

With this PR there are still 409 passing tests:
https://github.com/asdf-format/asdf-standard/actions/runs/17046203684/job/48322612491#step:10:101

While checking the tests I noticed a `DeprecationWarning` for `Traversable` and:
- fixed that as part of this PR (only in a docstring and test)
- turned warnings into errors so hopefully these won't go unnoticed

This is one in a series of PRs updating "downstream" users of the pytest asdf plugin.