### PR TITLE
fix time-1.4.0

### DIFF
--- a/resources/schemas/stsci.edu/asdf/time/time-1.4.0.yaml
+++ b/resources/schemas/stsci.edu/asdf/time/time-1.4.0.yaml
@@ -186,6 +186,9 @@ definitions:
       - unix
       - utime
       - tai_seconds
+      - cxcsec
+      - galexsec
+      - unix_tai
 
   other_format:
     description: |
@@ -201,9 +204,6 @@ definitions:
       - plot_date
       - ymdhms
       - datetime64
-      - cxcsec
-      - galexsec
-      - unix_tai
 
 anyOf:
   - $ref: "#/definitions/string_formats"


### PR DESCRIPTION
The reorganization in https://github.com/asdf-format/asdf-standard/pull/480 broke a few time formats since I missed that in the time schema in addition to the `oneOf` in `base_format`:
https://github.com/asdf-format/asdf-standard/blob/92bd63cc2124189c00b4f89d73de2d9326627d68/resources/schemas/stsci.edu/asdf/time/time-1.4.0.yaml#L239-L241
there is an exclusive consideration of only the formats listed in `format` in `format`:
https://github.com/asdf-format/asdf-standard/blob/92bd63cc2124189c00b4f89d73de2d9326627d68/resources/schemas/stsci.edu/asdf/time/time-1.4.0.yaml#L233
This fixes the broken formats (cxcsec, galexsec, unix_tai) by moving them from `other_format` to `format`.

This PR is tested in https://github.com/astropy/asdf-astropy/pull/270 (by setting the asdf-standard pin in that PR to this PR). I will open an issue to discuss moving these "astronomy" schemas to asdf-astropy since this PR highlights the problematic relationship of these two packages (asdf-standard has the astronmy schemas but can't test them without asdf-astropy which needs the schemas to implement support). The "asdf-standard" downstream failure in that PR is another sign of the mess that is these two packages (the job is testing asdf-standard main after install the source branch for this PR).
