### PR TITLE
Add missing transform schemas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+1.5.0 (unreleased)
+------------------
+
+- Add missing transform-1.0.0 and domain-1.0.0 schemas.
+  These are only used by legacy schemas and are not to be
+  used for new schemas. See asdf-transform-schemas for
+  newer versions of these schemas [#485]
+
 1.4.0 (2025-08-27)
 ------------------
 

--- a/docs/source/schemas/legacy.rst
+++ b/docs/source/schemas/legacy.rst
@@ -18,3 +18,5 @@ The following legacy schemas are not part of the most recent ASDF core schemas:
    time/time-1.1.0
    unit/quantity-1.1.0
    asdf-schema-1.1.0
+   transform/transform-1.0.0
+   transform/domain-1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,22 +62,9 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 asdf_schema_root = 'resources/schemas'
-asdf_schema_skip_tests = """
-    stsci.edu/asdf/asdf-schema-1.0.0.yaml
-    stsci.edu/asdf/wcs/celestial_frame-1.0.0.yaml
-    stsci.edu/asdf/wcs/celestial_frame-1.1.0.yaml
-    stsci.edu/asdf/wcs/frame-1.0.0.yaml
-    stsci.edu/asdf/wcs/frame-1.1.0.yaml
-    stsci.edu/asdf/wcs/spectral_frame-1.1.0.yaml
-    stsci.edu/asdf/wcs/step-1.1.0.yaml
-    stsci.edu/asdf/wcs/step-1.2.0.yaml
-    stsci.edu/asdf/wcs/wcs-1.1.0.yaml
-    stsci.edu/asdf/wcs/wcs-1.2.0.yaml
-    stsci.edu/yaml-schema/draft-01.yaml
-"""
 asdf_schema_tests_enabled = 'true'
 asdf_schema_ignore_unrecognized_tag = 'true'
-addopts = '--color=yes'
+addopts = '--color=yes -r a'
 filterwarnings = [
     "error",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,12 @@ where = ["src"]
 [tool.pytest.ini_options]
 asdf_schema_root = 'resources/schemas'
 asdf_schema_tests_enabled = 'true'
+asdf_schema_skip_tests = """
+    stsci.edu/asdf/wcs/step-1.1.0.yaml
+    stsci.edu/asdf/wcs/step-1.2.0.yaml
+    stsci.edu/asdf/wcs/wcs-1.1.0.yaml
+    stsci.edu/asdf/wcs/wcs-1.2.0.yaml
+"""
 asdf_schema_ignore_unrecognized_tag = 'true'
 addopts = '--color=yes -r a'
 filterwarnings = [

--- a/resources/schemas/stsci.edu/asdf/transform/domain-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/asdf/transform/domain-1.0.0.yaml
@@ -1,0 +1,45 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/domain-1.0.0"
+title: >
+  Defines the domain of an input axis. (deprecated since 1.1.0)
+
+description: >
+  Describes the range of acceptable input values to a particular
+  axis of a transform.
+
+examples:
+  -
+    - The domain `[0, 1)`.
+    - |
+      !transform/domain-1.0.0
+        lower: 0
+        upper: 1
+        includes_lower: true
+
+properties:
+  lower:
+    description: >
+      The lower value of the domain.  If not provided, the
+      domain has no lower limit.
+    type: number
+    default: -.inf
+
+  upper:
+    description: >
+      The upper value of the domain.  If not provided, the
+      domain has no upper limit.
+    type: number
+    default: .inf
+
+  includes_lower:
+    description: If `true`, the domain includes `lower`.
+    type: boolean
+    default: false
+
+  includes_upper:
+    description: If `true`, the domain includes `upper`.
+    type: boolean
+    default: false
+...

--- a/resources/schemas/stsci.edu/asdf/transform/transform-1.0.0.yaml
+++ b/resources/schemas/stsci.edu/asdf/transform/transform-1.0.0.yaml
@@ -1,0 +1,38 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://stsci.edu/schemas/asdf/transform/transform-1.0.0"
+title: >
+  A generic type used to mark where other transforms are accepted.
+
+description: >
+  These objects are designed to be nested in arbitrary ways to build up
+  transformation pipelines out of a number of low-level pieces.
+
+type: object
+properties:
+  name:
+    description: |
+      A user-friendly name for the transform, to give it extra
+      meaning.
+    type: string
+
+  domain:
+    description: |
+      The domain (range of valid inputs) to the transform.
+      Each entry in the list corresponds to an input dimension.
+    type: array
+    items:
+      $ref: "domain-1.0.0"
+
+  inverse:
+    description: |
+      Explicitly sets the inverse transform of this transform.
+
+      If the transform has a direct analytic inverse, this
+      property is usually not necessary, as the ASDF-reading tool
+      can provide it automatically.
+
+    $ref: "transform-1.0.0"
+additionalProperties: true
+...

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -17,6 +17,8 @@ EXCEPTIONS = {
     "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0",
     "http://stsci.edu/schemas/asdf/unit/unit-1.0.0",
     "http://stsci.edu/schemas/asdf/asdf-schema-1.1.0",
+    "http://stsci.edu/schemas/asdf/transform/transform-1.0.0",
+    "http://stsci.edu/schemas/asdf/transform/domain-1.0.0",
 }
 
 


### PR DESCRIPTION
Closes https://github.com/asdf-format/asdf-standard/issues/484

Add copies of transform-1.0.0 and domain-1.0.0 to the schemas. These are referenced by the core schema asdf-1.0.0 but were previously moved to asdf-transform-schemas. This resulted in a need to add asdf-transform-schemas to a dependency of asdf (but left this package incomplete).

See https://github.com/asdf-format/asdf/pull/1965 for a test showing that this fixes failures that would otherwise be seen if asdf drop asdf-transform-schemas as a dependency.