### PR TITLE
Update pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,12 +26,6 @@ repos:
     - id: rst-inline-touching-normal
     - id: text-unicode-replacement-char
 
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.15.0
-  hooks:
-    - id: pyupgrade
-      args: ["--py38-plus"]
-
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.6
   hooks:
@@ -46,11 +40,6 @@ repos:
     - id: ruff
       args: ["--fix"]
 
-- repo: https://github.com/pycqa/isort
-  rev: 5.12.0
-  hooks:
-    - id: isort
-
 - repo: https://github.com/psf/black
   rev: 23.10.1
   hooks:
@@ -60,9 +49,3 @@ repos:
   rev: 1.16.0
   hooks:
     - id: blacken-docs
-
-- repo: https://github.com/PyCQA/bandit
-  rev: 1.7.5
-  hooks:
-    - id: bandit
-      args: ["-c", "bandit.yaml"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: "reference_files/.*"
 repos:
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v6.0.0
   hooks:
     - id: check-added-large-files
     - id: check-ast
@@ -27,7 +27,7 @@ repos:
     - id: text-unicode-replacement-char
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.6
+  rev: v2.4.1
   hooks:
     - id: codespell
       args: ["--write-changes"]
@@ -35,17 +35,17 @@ repos:
         - tomli
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: 'v0.1.4'
+  rev: 'v0.13.0'
   hooks:
     - id: ruff
       args: ["--fix"]
 
 - repo: https://github.com/psf/black
-  rev: 23.10.1
+  rev: 25.1.0
   hooks:
     - id: black
 
 - repo: https://github.com/asottile/blacken-docs
-  rev: 1.16.0
+  rev: 1.20.0
   hooks:
     - id: blacken-docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ select = [
     "RUF",  # ruff specific, includes yesqa
 ]
 extend-ignore = [
-    "RUF005",
+    "RUF005", # Checks for uses of the + operator to concatenate collections.
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,14 @@ select = [
     "UP", # pyupgrade
     "RUF",  # ruff specific, includes yesqa
 ]
+extend-ignore = [
+    "RUF005",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"test_*.py" = ["S101"]
+"tests/*" = ["S101"]
+"scripts/*" = ["S603"]
 
 [tool.codespell]
 skip="*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,9 +109,15 @@ extend-ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"test_*.py" = ["S101"]
-"tests/*" = ["S101"]
-"scripts/*" = ["S603"]
+"test_*.py" = [
+    "S101", # Checks for uses of the assert keyword.
+]
+"tests/*" = [
+    "S101", # Checks for uses of the assert keyword.
+]
+"scripts/*" = [
+    "S603", # Check for method calls that initiate a subprocess without a shell.
+]
 
 [tool.codespell]
 skip="*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,13 +92,18 @@ force-exclude = '''
 )
 '''
 
-[tool.isort]
-profile = "black"
-filter_files = true
-line_length = 120
-
 [tool.ruff]
 line-length = 120
+
+[too.ruff.link]
+select = [
+    "E", # pycodestyle
+    "F", # pyflakes, autoflake
+    "I", # isort
+    "S", # bandit
+    "UP", # pyupgrade
+    "RUF",  # ruff specific, includes yesqa
+]
 
 [tool.codespell]
 skip="*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ force-exclude = '''
 [tool.ruff]
 line-length = 120
 
-[too.ruff.lint]
+[tool.ruff.lint]
 select = [
     "E", # pycodestyle
     "F", # pyflakes, autoflake

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ force-exclude = '''
 [tool.ruff]
 line-length = 120
 
-[too.ruff.link]
+[too.ruff.lint]
 select = [
     "E", # pycodestyle
     "F", # pyflakes, autoflake

--- a/src/asdf_standard/__init__.py
+++ b/src/asdf_standard/__init__.py
@@ -1,4 +1,4 @@
 from ._version import version as __version__
 from .resource import DirectoryResourceMapping
 
-__all__ = ["__version__", "DirectoryResourceMapping"]
+__all__ = ["DirectoryResourceMapping", "__version__"]

--- a/src/asdf_standard/resource.py
+++ b/src/asdf_standard/resource.py
@@ -74,11 +74,9 @@ class DirectoryResourceMapping(Mapping):
         yield from self._uri_to_file
 
     def __repr__(self):
-        return "{}({!r}, {!r}, recursive={!r}, filename_pattern={!r}, stem_filename={!r})".format(
-            self.__class__.__name__,
-            self._root,
-            self._uri_prefix,
-            self._recursive,
-            self._filename_pattern,
-            self._stem_filename,
+        return (
+            f"{self.__class__.__name__}({self._root!r}, {self._uri_prefix!r}, "
+            f"recursive={self._recursive!r}, "
+            f"filename_pattern={self._filename_pattern!r}, "
+            f"stem_filename={self._stem_filename!r})"
         )

--- a/tests/common.py
+++ b/tests/common.py
@@ -74,7 +74,7 @@ def yaml_tag_to_id(yaml_tag):
 
 
 def _relative_stem(path):
-    return f"{str((path.parent).relative_to(SCHEMAS_PATH))}/{str(path.stem)}"
+    return f"{(path.parent).relative_to(SCHEMAS_PATH)!s}/{path.stem!s}"
 
 
 def path_to_tag(path):

--- a/tests/test_wcs.py
+++ b/tests/test_wcs.py
@@ -2,6 +2,7 @@
 The WCS schemas are deprecated, but we need to continue testing them
 to ensure that older versions of the standard are supported.
 """
+
 import pytest
 from common import SCHEMAS_PATH, list_latest_schema_paths, list_schema_paths
 


### PR DESCRIPTION
This updates the pre-commit hooks to more closely align with those in asdf.

Replaces pyupgrade, isort and bandit with equivalent ruff rules.